### PR TITLE
Conda environment file for PhysiCell Studio dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: pmb
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pandas 
+  - matplotlib 
+  - pyqt 
+  - libxml2 
+  - python 
+  - scipy


### PR DESCRIPTION
I couldn't find it anywhere, so I made one : A conda environment file to easily build an conda environment with PhysiCell Studio dependencies. 
Usage : 
```
conda env create -f environment.yml 
```

This needs a lot more testing, I just built it quickly for Laurence on MacOS. But first I wanted to know if it was needed. 