### PR TITLE
bug fix when renaming copied cell def

### DIFF
--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -660,6 +660,14 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
 
         self.param_d[cdname_copy]["ID"] = str(self.new_cell_def_count)  # rwh Note: we won't do this if we auto-generate the ID #s at "save"
 
+        for cdname in self.param_d.keys():    # for each cell def, set how it interacts with new cell based on how it interacted with original cell
+            self.param_d[cdname]['live_phagocytosis_rate'][cdname_copy] = self.param_d[cdname]['live_phagocytosis_rate'][cdname_original]
+            self.param_d[cdname]['attack_rate'][cdname_copy] = self.param_d[cdname]['live_phagocytosis_rate'][cdname_original]
+            self.param_d[cdname]['fusion_rate'][cdname_copy] = self.param_d[cdname]['live_phagocytosis_rate'][cdname_original]
+            self.param_d[cdname]['transformation_rate'][cdname_copy] = self.param_d[cdname]['live_phagocytosis_rate'][cdname_original]
+
+            self.param_d[cdname]['cell_adhesion_affinity'][cdname_copy] = self.param_d[cdname]['cell_adhesion_affinity'][cdname_original]  # default affinity
+           
         logging.debug(f'--> copy_cell_def():\n {self.param_d[cdname_copy]}')
         # print('2) copy_cell_def(): param_d.keys=',self.param_d.keys())
 


### PR DESCRIPTION
after copying, make sure all previously-defined cells' dictionaries a…re updated to have a value for the new one, and have it copy the value from the previous one