### PR TITLE
Solved crash when setting max time, fixed weird stretch in death tab, added bin icon to delete button.

### DIFF
--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -323,7 +323,7 @@ class CellDef(QWidget):
         # self.controls_hbox.addWidget(self.copy_button)
         tree_w_hbox.addWidget(self.copy_button)
 
-        self.delete_button = QPushButton("Delete")
+        self.delete_button = QPushButton(icon=QIcon(sys.path[0] +"/icon/bin.svg"), parent=self)
         self.delete_button.clicked.connect(self.delete_cell_def)
         self.delete_button.setStyleSheet("QPushButton {background-color: yellow; color: black;}")
         # self.controls_hbox.addWidget(self.delete_button)

--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -1781,12 +1781,14 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.apoptosis_rb2.toggled.connect(self.apoptosis_phase_transition_cb)
 
         hbox.addWidget(self.apoptosis_rb1)
+
         hbox.addWidget(self.apoptosis_rb2)
 
         radio_frame = QFrame()
         radio_frame.setStyleSheet("QFrame{ border : 1px solid black; }")
         radio_frame.setLayout(hbox)
         radio_frame.setFixedWidth(210)  # omg
+        radio_frame.setFixedHeight(30)
         idr += 1
         glayout.addWidget(radio_frame, idr,0, 1,2) # w, row, column, rowspan, colspan
 
@@ -2001,6 +2003,7 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         radio_frame.setStyleSheet("QFrame{ border : 1px solid black; }")
         radio_frame.setLayout(hbox)
         radio_frame.setFixedWidth(210)  # omg
+        radio_frame.setFixedHeight(30)
         idr += 1
         glayout.addWidget(radio_frame, idr,0, 1,2) # w, row, column, rowspan, colspan
 

--- a/bin/config_tab.py
+++ b/bin/config_tab.py
@@ -514,8 +514,11 @@ class Config(QWidget):
 
 
     def add_day_cb(self):
-        max_time = float(self.max_time.text())
-        print("max_time=",max_time)
+        if not self.max_time.text():
+            max_time = float(0.0)
+        else:
+            max_time = float(self.max_time.text())
+        print("max_time=", max_time)
         max_time += 1440
         self.max_time.setText(f"{max_time}")
 


### PR DESCRIPTION
Hi Randy!

Three small modification:

1) I have modified the Death tab so the box which contains the transition rate and the duration no longer stretch weirdly but it remains constant when changing the window resolution.

2) Solved a bug that was causing Studio to crash when pressing the +1 day in Config Basics when setting Max Time, in case the box on the side is empty. It happened to me several times because when I want to quickly reset the max time to a different value, I usually double click on it, delete the number, and then press the button +1. With the fix it no longer crashes.

3) Added a bin icon in Cell Types tab instead of the button with written "delete". I did for the intracellular tab too, in order to save some space. Also I think it looks nice...

That's it for now, let me know what you think!

Marco