### PR TITLE
Fixing bug in the plot tab when running PhysiBoSS

### DIFF
--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -1372,9 +1372,11 @@ class VisBase():
             self.physiboss_hbox = QHBoxLayout()
 
             self.physiboss_cell_type_combobox = QComboBox()
+            self.physiboss_cell_type_combobox.setFixedWidth(120)
             self.physiboss_cell_type_combobox.setEnabled(False)
             self.physiboss_cell_type_combobox.currentIndexChanged.connect(self.physiboss_vis_cell_type_cb)
             self.physiboss_node_combobox = QComboBox()
+            self.physiboss_node_combobox.setFixedWidth(120)
             self.physiboss_node_combobox.setEnabled(False)
             self.physiboss_node_combobox.currentIndexChanged.connect(self.physiboss_vis_node_cb)
             self.physiboss_hbox.addWidget(self.physiboss_cell_type_combobox)

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -31,7 +31,7 @@ import pandas
 
 from PyQt5 import QtCore, QtGui
 from PyQt5.QtWidgets import QFrame,QApplication,QWidget,QTabWidget,QFormLayout,QLineEdit, QGroupBox, QHBoxLayout,QVBoxLayout,QRadioButton,QLabel,QCheckBox,QComboBox,QScrollArea,  QMainWindow,QGridLayout, QPushButton, QFileDialog, QMessageBox, QStackedWidget, QSplitter
-from PyQt5.QtWidgets import QCompleter, QSizePolicy
+from PyQt5.QtWidgets import QCompleter, QSizePolicy, QSpacerItem
 from PyQt5.QtCore import QSortFilterProxyModel
 from PyQt5.QtSvg import QSvgWidget
 from PyQt5.QtGui import QPainter
@@ -622,9 +622,10 @@ class VisBase():
         self.scroll_plot = QScrollArea()  # might contain centralWidget
 
 
-        splitter = QSplitter()
+        splitter = QSplitter(self)
         self.scroll_params = QScrollArea()
-        splitter.addWidget(self.scroll_params)
+        self.scroll_params.setWidgetResizable(True)
+        self.scroll_params.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         #---------------------
         self.stackw = QStackedWidget()
@@ -635,6 +636,8 @@ class VisBase():
 
         self.vbox = QVBoxLayout()
         self.controls1.setLayout(self.vbox)
+        self.controls1.setStyleSheet(self.stylesheet)
+        self.controls1.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         hbox = QHBoxLayout()
         arrow_button_width = 40
@@ -681,6 +684,9 @@ class VisBase():
         self.vbox.addWidget(QHLine())
 
         self.cells_hbox = QHBoxLayout()
+
+        self.hz_stretch_item = QSpacerItem(10, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
         self.cells_checkbox = QCheckBox_custom("cells")
         self.cells_checkbox.setChecked(True)
         self.cells_checkbox.clicked.connect(self.cells_toggle_cb)
@@ -705,6 +711,7 @@ class VisBase():
             self.cells_mat_rb.clicked.connect(self.cells_svg_mat_cb)
             # hbox2.addWidget(self.cells_mat_rb)
             self.cells_hbox.addWidget(self.cells_mat_rb)
+            self.cells_hbox.addSpacerItem(self.hz_stretch_item)
             # hbox2.addStretch(1)  # not sure about this, but keeps buttons shoved to left
 
             # radio_frame = QFrame()
@@ -738,6 +745,7 @@ class VisBase():
         # self.cell_scalar_combobox.setEnabled(True)   # for 3D
         self.cell_scalar_combobox.setEnabled(self.model3D_flag)   # for 3D
         hbox.addWidget(self.cell_scalar_combobox)
+        hbox.addItem(self.hz_stretch_item)
         self.vbox.addLayout(hbox)
 
         hbox = QHBoxLayout()
@@ -837,6 +845,7 @@ class VisBase():
         hbox = QHBoxLayout()
         hbox.addWidget(self.substrates_combobox)
         hbox.addWidget(self.substrates_cbar_combobox)
+        hbox.addItem(self.hz_stretch_item)
 
         self.vbox.addLayout(hbox)
 
@@ -941,7 +950,7 @@ class VisBase():
         # self.discrete_cells_combobox.setEnabled(False)
         self.discrete_cells_combobox.currentIndexChanged.connect(self.population_choice_cb)
         hbox.addWidget(self.discrete_cells_combobox)
-
+        hbox.addItem(self.hz_stretch_item)
         self.vbox.addLayout(hbox)
 
 
@@ -984,10 +993,16 @@ class VisBase():
         # done in subclasses now
         # self.scroll_plot.setWidget(self.canvas) # self.config_params = QWidget()
 
+        self.stretch_widget = QWidget()
+        self.stretch_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        self.vbox.addWidget(self.stretch_widget)
+
         self.stackw.addWidget(self.controls1)
         self.stackw.setCurrentIndex(0)
 
-        self.scroll_params.setWidget(self.stackw)
+        self.scroll_params.setWidget(self.controls1)
+        splitter.addWidget(self.scroll_params)
         splitter.addWidget(self.scroll_plot)
 
         self.show_plot_range = False
@@ -1339,12 +1354,16 @@ class VisBase():
         if not self.physiboss_widgets:
             
             self.physiboss_widgets = True
-                
+
+            self.vbox.removeWidget(self.stretch_widget) #removes the placeholder for the "stretcher widget" to place it at the bottom
+            self.cells_hbox.removeItem(self.hz_stretch_item) #same as above
+
             self.cells_physiboss_rb = QRadioButton("physiboss")
             self.cells_physiboss_rb.setChecked(False)
             self.cells_physiboss_rb.clicked.connect(self.cells_svg_mat_cb)
             self.cells_hbox.addWidget(self.cells_physiboss_rb)
-                
+            self.cells_hbox.addItem(self.hz_stretch_item)
+
             self.physiboss_qline = QHLine()
             self.vbox.addWidget(self.physiboss_qline)
             
@@ -1358,6 +1377,7 @@ class VisBase():
             self.physiboss_node_combobox.currentIndexChanged.connect(self.physiboss_vis_node_cb)
             self.physiboss_hbox.addWidget(self.physiboss_cell_type_combobox)
             self.physiboss_hbox.addWidget(self.physiboss_node_combobox)
+            self.physiboss_hbox.addItem(self.hz_stretch_item)
 
             self.vbox.addLayout(self.physiboss_hbox)
             
@@ -1366,7 +1386,8 @@ class VisBase():
             self.physiboss_population_counts_button.setEnabled(False)
             self.physiboss_population_counts_button.clicked.connect(self.physiboss_state_counts_cb)
             self.vbox.addWidget(self.physiboss_population_counts_button)
-        
+            self.vbox.addWidget(self.stretch_widget)
+
     def physiboss_vis_hide(self):
         print("\n--------- physiboss_vis_hide()")
 

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -843,6 +843,8 @@ class VisBase():
         self.vbox.addWidget(self.substrates_checkbox)
 
         hbox = QHBoxLayout()
+        self.substrates_combobox.setFixedWidth(120)
+        self.substrates_cbar_combobox.setFixedWidth(120)
         hbox.addWidget(self.substrates_combobox)
         hbox.addWidget(self.substrates_cbar_combobox)
         hbox.addItem(self.hz_stretch_item)


### PR DESCRIPTION
Hi Randy!

I noticed that when you run a model with PhysiBoSS, in the plot tab all the buttons are squeezed. 
This was a bit annoying so I have tried to solve it.

First, I checked the structure of the plot tab and I noticed the following:

- QVBoxLayout (main_layout)
  |
  \-- QSplitter (splitter)
      |
      +-- QScrollArea (scroll_params)
      |   |
      |   \-- QStackedWidget (stackw)  <-- THIS
      |       |
      |       \-- QWidget (controls1)
      |           |
      |           \-- QVBoxLayout (vbox)
      |               |
      |               \-- [Widgets added to vbox]
      |
      \-- QScrollArea (scroll_plot)
          |
          \-- [Content of scroll_plot]

As you can see in the improvised graph, there is this widget stackw, that is not very used in the code. Actually it is not used at all. So I have tried to remove it to avoid too many embedding. 
Then we have the scroll area "scroll_params". I made sure that it was resizable and deformable, so when adding widget in the embedded vbox, they will occupy the necessary space without being deformed.
Since I did not need anymore stackw, I changed the StyleSheet of controls1 (which is the widget that "contains" the vbox with all the other params widget) and modified the policy so that it can expand and occupy all the necessary space.

```
splitter = QSplitter(self)
self.scroll_params = QScrollArea()
self.scroll_params.setWidgetResizable(True)
self.scroll_params.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
```

```
self.controls1.setStyleSheet(self.stylesheet)
self.controls1.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
```

With just those adjustments, the params section (scroll_params) basically will be distributed in the first part of the splitter, occupying all the space, and when you change the size of the window, all the buttons that do not have a fixed length or height, will be deformed.

To avoid this, I have added some stretches. But instead of just using widget.addStretch() I prefered added some kind of "phantom" widget that can be deformed horizontally. The result is exactly the same, with the difference that since it is a widget, one can remove it if another widget is added dynamically, like in the case of the physiboss radio button! This is quite handy!

```
self.hz_stretch_item = QSpacerItem(10, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
self.cells_hbox.addSpacerItem(self.hz_stretch_item)
```

Finally, following the same principle, I have added a "phantom" widget that can be just be deformed vertically, at the bottom of the scroll_params, right after the button Legend (.svg). This is useful because, in case of a Physiboss simulation, the widget is removed from below the legend button and re-positioned after the Boolean states plot button.

```
self.stretch_widget = QWidget()
self.stretch_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
self.vbox.addWidget(self.stretch_widget)
```

```
self.vbox.removeWidget(self.stretch_widget) #removes the placeholder for the "stretcher widget" to place it at the bottom
self.cells_hbox.removeItem(self.hz_stretch_item) #same as above
```

With this, the scroll_params is not getting deformed when adding dynamically more widget or vertical or horizontal layout. The only problem is the QHline that does not have a fixed length so it gets horizontally stretched... I think it is matter of taste.

I can of course re-align better everything if I missed anything, or use the common stretch (apart for the one for the radio button that is required).

I would really appreciate your opinion about this!

Best,

Marco

**BEFORE**

![Capture d’écran du 2024-01-08 14-42-37](https://github.com/PhysiCell-Tools/PhysiCell-Studio/assets/25529632/444ddcf3-3e2d-43c9-bcdb-39de1ad3d1ab)

**AFTER**
![Capture d’écran du 2024-01-09 15-57-34](https://github.com/PhysiCell-Tools/PhysiCell-Studio/assets/25529632/cef0b0dd-7461-4367-8903-2c6983706aa4)

