### PR TITLE
fix handling of anndata not loaded

### DIFF
--- a/bin/bioinf_import_tab.py
+++ b/bin/bioinf_import_tab.py
@@ -2334,6 +2334,7 @@ class BioinfImport(QWidget):
             base_widget.setLayout(vbox)
             self.layout = QVBoxLayout(self)  # leave this!
             self.layout.addWidget(base_widget)
+            ics_tab.bioinf_import_flag = False # don't allow other tabs to proceed with doing biwt stuff
             return
 
         self.config_tab = config_tab


### PR DESCRIPTION
If `anndata` was not installed, our helpful message was not showing up because `fill_gui` was trying to do stuff with the biwt tab. This fixes that by turning the `bioinf_import` flag to `False` if `anndata` is not loaded.