### PR TITLE
quick fix just hard-coding all bioinf flags as false

### DIFF
--- a/bin/studio-rules.py
+++ b/bin/studio-rules.py
@@ -288,7 +288,7 @@ class PhysiCellXMLCreator(QWidget):
 
         if self.studio_flag:
             logging.debug(f'studio.py: creating ICs, Run, and Plot tabs')
-            self.ics_tab = ICs(self.config_tab, self.celldef_tab)
+            self.ics_tab = ICs(self.config_tab, self.celldef_tab, False, False, False)
             self.ics_tab.fill_celltype_combobox()
             self.ics_tab.reset_info()
 

--- a/bin/studio_ecm.py
+++ b/bin/studio_ecm.py
@@ -340,7 +340,7 @@ class PhysiCellXMLCreator(QWidget):
 
         if self.studio_flag:
             logging.debug(f'studio.py: creating ICs, Run, and Plot tabs')
-            self.ics_tab = ICs(self.config_tab, self.celldef_tab)
+            self.ics_tab = ICs(self.config_tab, self.celldef_tab, False, False, False)
             self.ics_tab.fill_celltype_combobox()
             self.ics_tab.reset_info()
 

--- a/tests/studio_for_pytest.py
+++ b/tests/studio_for_pytest.py
@@ -422,7 +422,7 @@ class PhysiCellXMLCreator(QWidget):
 
         if self.studio_flag:
             logging.debug(f'studio.py: creating ICs, Run, and Plot tabs')
-            self.ics_tab = ICs(self.config_tab, self.celldef_tab)
+            self.ics_tab = ICs(self.config_tab, self.celldef_tab, False, False, False)
             self.ics_tab.fill_celltype_combobox()
             self.ics_tab.reset_info()
 


### PR DESCRIPTION
fix other files that launch studio so that they can at least run with ICs tab. For now, just default to them not integrating with the biwt