### PR TITLE
update to upstream/dev and allow biwt in vECM

### DIFF
--- a/bin/studio_ecm.py
+++ b/bin/studio_ecm.py
@@ -78,7 +78,7 @@ def quit_cb():
 
   
 class PhysiCellXMLCreator(QWidget):
-    def __init__(self, config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, is_movable_flag, ecm_flag, pytest_flag, parent = None):
+    def __init__(self, config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, is_movable_flag, ecm_flag, pytest_flag, bioinf_import_flag, bioinf_import_test_flag, bioinf_import_test_spatial_flag, parent = None):
         super(PhysiCellXMLCreator, self).__init__(parent)
         if ecm_flag:
             from vis_tab_ecm import Vis 
@@ -106,6 +106,7 @@ class PhysiCellXMLCreator(QWidget):
         self.nanohub_flag = nanohub_flag 
         self.ecm_flag = ecm_flag 
         self.pytest_flag = pytest_flag 
+        self.bioinf_import_flag = bioinf_import_flag
         print("PhysiCellXMLCreator(): self.nanohub_flag= ",self.nanohub_flag)
 
         self.rules_tab_index = None
@@ -340,7 +341,7 @@ class PhysiCellXMLCreator(QWidget):
 
         if self.studio_flag:
             logging.debug(f'studio.py: creating ICs, Run, and Plot tabs')
-            self.ics_tab = ICs(self.config_tab, self.celldef_tab, False, False, False)
+            self.ics_tab = ICs(self.config_tab, self.celldef_tab, self.bioinf_import_flag, bioinf_import_test_flag, bioinf_import_test_spatial_flag)
             self.ics_tab.fill_celltype_combobox()
             self.ics_tab.reset_info()
 
@@ -1317,6 +1318,9 @@ def main():
     nanohub_flag = False
     is_movable_flag = False
     pytest_flag = False
+    bioinf_import_flag = False
+    bioinf_import_test_flag = False
+    bioinf_import_test_spatial_flag = False
     try:
         parser = argparse.ArgumentParser(description='PhysiCell Studio.')
 
@@ -1329,6 +1333,9 @@ def main():
         # parser.add_argument("--is_movable", help="checkbox for mechanics is_movable", action="store_true")
         parser.add_argument("-c", "--config", type=str, help="config file (.xml)")
         parser.add_argument("-e", "--exec", type=str, help="executable model")
+        parser.add_argument("--bioinf_import", help="display bioinformatics import tab on ICs tab", action="store_true")
+        parser.add_argument("--bioinf_import_test", help="immediately start loading anndata w/o spatial", action="store_true")
+        parser.add_argument("--bioinf_import_test_spatial", help="immediately start loading spatial anndata", action="store_true")
 
         exec_file = 'project'  # for template sample
 
@@ -1395,6 +1402,12 @@ def main():
             else:
                 print("exec_file is NOT valid: ", args.exec)
                 sys.exit()
+        if args.bioinf_import:
+            bioinf_import_flag = True
+        if args.bioinf_import_test:
+            bioinf_import_test_flag = True
+        if args.bioinf_import_test_spatial:
+            bioinf_import_test_spatial_flag = True
     except:
         # print("Error parsing command line args.")
         sys.exit(-1)
@@ -1468,7 +1481,7 @@ def main():
             # print("Warning: Rules module not found.\n")
 
     # print("calling PhysiCellXMLCreator with rules_flag= ",rules_flag)
-    ex = PhysiCellXMLCreator(config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, is_movable_flag, ecm_flag, pytest_flag)
+    ex = PhysiCellXMLCreator(config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, is_movable_flag, ecm_flag, pytest_flag, bioinf_import_flag, bioinf_import_test_flag, bioinf_import_test_spatial_flag)
     print("size=",ex.size())  # = PyQt5.QtCore.QSize(1100, 770)
     # ex.setFixedWidth(1101)  # = PyQt5.QtCore.QSize(1100, 770)
     # print("width=",ex.size())


### PR DESCRIPTION
A better fix for the `studio_ecm.py` to allow for that to use the biwt. I don't know the differences between `studio.py` and `studio_ecm.py`, so we should only merge after we know it won't break anything. I do not know how to test since I don't know what `studio_ecm.py` requires to run.