### PR TITLE
Pip dependencies now explicit in environment.yml, not depending on requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,9 @@ dependencies:
   - python
   - pip
   - pip:
-    - -r requirements.txt
+    - PyQt5
+    - matplotlib
+    - scipy
+    - pandas
+    - simulariumio[physicell]
+    - anndata


### PR DESCRIPTION
As much as I like the idea of just needing to update one file, this is not working in Anaconda Navigator (A GUI for conda). 

I'm giving a live tutorial on Tuesday, and with this fix I have it "easily" working on Windows. Wish me luck