### PR TITLE
Updated environment.yml, with most dependencies from conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,12 @@ channels:
 dependencies:
   - paraview 
   - python
+  - pyqt5-sip
+  - matplotlib
+  - scipy
+  - pandas
+  - anndata
   - pip
   - pip:
-    - PyQt5
-    - matplotlib
-    - scipy
-    - pandas
     - simulariumio[physicell]
-    - anndata
+


### PR DESCRIPTION
This allows conda to get more dependencies needed by Qt, which are not available otherwise. 