### PR TITLE
update .gitignore for git submodule edge case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-
-bin/__pycache__/cell_def_tab.cpython-39.pyc
-bin/__pycache__/config_tab.cpython-39.pyc
-bin/__pycache__/legend_tab.cpython-39.pyc
-bin/__pycache__/microenv_tab.cpython-39.pyc
-bin/__pycache__/populate_tree_cell_defs.cpython-39.pyc
-bin/__pycache__/pyMCDS_cells.cpython-39.pyc
-bin/__pycache__/run_tab.cpython-39.pyc
-bin/__pycache__/user_params_tab.cpython-39.pyc
-bin/__pycache__/vis_tab.cpython-39.pyc
+# these should be ignored by git automatically, but I've seen them become track-able when using studio as a git submodule
+.DS_Store
+__pycache__/


### PR DESCRIPTION
Not sure if others have seen this happen, but I created studio as a submodule for the first today and `bin/__pycache__/` was track-able. This resolves that issue and updates the gitignore to be more concise, too.

I think I also saw a `.DS_Store` file crop up at some point, so I included that, too, for good measure.