### PR TITLE
fix redundant motion_notify_event on IC canvas

### DIFF
--- a/bin/ics_tab.py
+++ b/bin/ics_tab.py
@@ -964,7 +964,6 @@ class ICs(QWidget):
         self.canvas.mpl_connect("motion_notify_event", self.mouseMoved) # for substrate placement when point not selected
         self.canvas.mpl_connect('axes_enter_event', self.on_enter_axes)
         self.canvas.mpl_connect('axes_leave_event', self.on_leave_axes)
-        self.canvas.mpl_connect("motion_notify_event", self.mouseMoved) # for substrate placement when point not selected
         self.canvas.setStyleSheet("background-color:transparent;")
 
         self.ax0 = self.figure.add_subplot(111, adjustable='box')


### PR DESCRIPTION
clearly adding a duplicate `motion_notify_event`. Not typically a problem, but I have seen the coordinates become pretty slow when there's lots of cells present. so this will cut that latency in half.