### PR TITLE
Added support for new PhysiBoSS state filenames

### DIFF
--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -1546,13 +1546,16 @@ class VisBase():
                 print("vis_tab.py: physiboss_state_counts_cb(): error performing mcds.get_cell_df()['cell_type']")
                 return
 
-
-            physiboss_state_file = os.path.join(self.output_dir, "states_%08d.csv" % i_frame)
-
+            physiboss_state_file = os.path.join(self.output_dir, "output%08d_boolean_intracellular.csv" % i_frame)
+        
             if not Path(physiboss_state_file).is_file():
-                print("vis_tab.py: physiboss_state_counts_cb(): error file not found ",physiboss_state_file)
-                return
-    
+                
+                physiboss_state_file = os.path.join(self.output_dir, "states_%08d.csv" % i_frame)
+                
+                if not Path(physiboss_state_file).is_file():
+                    print("vis_tab.py: plot_cell_physiboss(): error file not found ",physiboss_state_file)
+                    return
+        
             name_cellline = list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]
             id_cellline = list(self.celldef_tab.param_d.keys()).index(name_cellline)
     

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -671,12 +671,16 @@ class Vis(VisBase, QWidget):
         except:
             print("vis_tab.py: plot_cell_physiboss(): error performing mcds.get_cell_df()['cell_type']")
             return
-            
-        physiboss_state_file = os.path.join(self.output_dir, "states_%08d.csv" % frame)
+        
+        physiboss_state_file = os.path.join(self.output_dir, "output%08d_boolean_intracellular.csv" % frame)
         
         if not Path(physiboss_state_file).is_file():
-            print("vis_tab.py: plot_cell_physiboss(): error file not found ",physiboss_state_file)
-            return
+            
+            physiboss_state_file = os.path.join(self.output_dir, "states_%08d.csv" % frame)
+            
+            if not Path(physiboss_state_file).is_file():
+                print("vis_tab.py: plot_cell_physiboss(): error file not found ",physiboss_state_file)
+                return
         
         cell_scalar = {id: 9 for id in mcds.get_cell_df().index}
         

--- a/bin/vis_tab_ecm.py
+++ b/bin/vis_tab_ecm.py
@@ -656,12 +656,16 @@ class Vis(VisBase, QWidget):
                 print("vis_tab.py: plot_cell_scalar(): error performing mcds.get_cell_df()['cell_type']")
                 return
             
-            physiboss_state_file = os.path.join(self.output_dir, "states_%08d.csv" % frame)
-            
+            physiboss_state_file = os.path.join(self.output_dir, "output%08d_boolean_intracellular.csv" % frame)
+        
             if not Path(physiboss_state_file).is_file():
-                print("vis_tab.py: plot_cell_scalar(): error file not found ",physiboss_state_file)
-                return
             
+                physiboss_state_file = os.path.join(self.output_dir, "states_%08d.csv" % frame)
+                
+                if not Path(physiboss_state_file).is_file():
+                    print("vis_tab.py: plot_cell_physiboss(): error file not found ",physiboss_state_file)
+                    return
+        
             cell_scalar = {}
             with open(physiboss_state_file, newline='') as csvfile:
                 states_reader = csv.reader(csvfile, delimiter=',')


### PR DESCRIPTION
As a part of the new support of MultiCellDS for PhysiBoSS state files, we changed the name of the files from state_XXXXXXXX.csv to outputXXXXXXXX_boolean_intracellular.csv. 
This fix checks first if the new filename exists, otherwise checks the old one, and fails if none exists. 
In a future release, this will all be part of pcdl data, but I wanted to have a quick (and dirty) fix first to make sure nothing is broken. 