### PR TITLE
Add rest of new damage/attack to rules. import old damage rate rule

### DIFF
--- a/bin/populate_tree_cell_defs.py
+++ b/bin/populate_tree_cell_defs.py
@@ -1178,6 +1178,9 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
                 cell_def_tab.param_d[cell_def_name]["necrotic_phagocytosis_rate"] = '0.0'
                 cell_def_tab.param_d[cell_def_name]["other_dead_phagocytosis_rate"] = '0.0'
                 cell_def_tab.param_d[cell_def_name]["attack_damage_rate"] = '1.0'
+                cell_def_tab.param_d[cell_def_name]["attack_duration"] = '0.1'
+                cell_def_tab.param_d[cell_def_name]["damage_rate"] = '0.0'
+                cell_def_tab.param_d[cell_def_name]["damage_repair_rate"] = '0.0'
 
                 cds_uep = cell_def_tab.xml_root.find('.//cell_definitions')  # find unique entry point
                 if cds_uep is None:
@@ -1203,23 +1206,20 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
                         dead_phagocytosis_rates[index] = cep.find(name).text
                     cell_def_tab.param_d[cell_def_name][name] = dead_phagocytosis_rates[index]
 
-                try:  # pre 1.14.0
+                cell_def_tab.pre_v1_14_0_damage_rate = cep.find("damage_rate") is not None
+                if cell_def_tab.pre_v1_14_0_damage_rate:
                     val = cep.find("damage_rate").text
-                    # cell_def_tab.param_d[cell_def_name]["damage_rate"] = val
-                    cell_def_tab.param_d[cell_def_name]["attack_damage_rate"] = val  # change tag - 1.14.0
-                except:
-                    try:
-                        val = cep.find("attack_damage_rate").text
-                        cell_def_tab.param_d[cell_def_name]["attack_damage_rate"] = val
-                    except:
-                        print("\nError: missing damage_rate or attack_damage_rate in XML")
-                        sys.exit()
+                elif cep.find("attack_damage_rate") is not None: # change tag - 1.14.0
+                    val = cep.find("attack_damage_rate").text
+                else: # no attack damage rate found, default to 1.0
+                    val = '1.0'
+                cell_def_tab.param_d[cell_def_name]["attack_damage_rate"] = val
 
-                try:  # 1.14.0
+                if cep.find("attack_duration") is not None:  # 1.14.0
                     val = cep.find("attack_duration").text
-                    cell_def_tab.param_d[cell_def_name]["attack_duration"] = val
-                except:  # default, if missing, e.g., pre-1.14.0
-                    cell_def_tab.param_d[cell_def_name]["attack_duration"] = "0.1"
+                else:
+                    val = '0.1'
+                cell_def_tab.param_d[cell_def_name]["attack_duration"] = val
 
                 uep2 = uep.find(cell_interactions_path + "//live_phagocytosis_rates")
                 logging.debug(f'uep2= {uep2}')

--- a/bin/rules_tab.py
+++ b/bin/rules_tab.py
@@ -1080,6 +1080,8 @@ class Rules(QWidget):
                 cell_type = behavior[12:]   # length of "phagocytose" 
                 print("      cell_type (for phagocytose)=",cell_type)
                 base_val = self.celldef_tab.param_d[key0]['live_phagocytosis_rate'][cell_type]
+        elif behavior == "attack damage rate":
+            base_val = self.celldef_tab.param_d[key0]["attack_damage_rate"]
         elif behavior == "attack duration":
             base_val = self.celldef_tab.param_d[key0]["attack_duration"]
         elif btokens[0] == "attack":
@@ -1097,6 +1099,8 @@ class Rules(QWidget):
             base_val = self.celldef_tab.param_d[key0]['transformation_rate'][cell_type]
         elif behavior == "damage rate":
             base_val = self.celldef_tab.param_d[key0]["damage_rate"]
+        elif behavior == "damage repair rate":
+            base_val = self.celldef_tab.param_d[key0]["damage_repair_rate"]
         elif "custom:" in btokens[0]:
             custom_data_name = btokens[0].split(':')[-1] # return string after colon
             print(custom_data_name, self.celldef_tab.param_d[key0]['custom_data'][custom_data_name])
@@ -1315,6 +1319,13 @@ class Rules(QWidget):
                             irow += 1
                             elm[self.rules_response_idx] = "phagocytose other dead cell"
                             self.fill_rule_row(irow, elm)
+
+                        if elm[self.rules_response_idx] == "damage rate" and hasattr(self.celldef_tab, "pre_v1_14_0_damage_rate") and self.celldef_tab.pre_v1_14_0_damage_rate:
+                            elm[self.rules_response_idx] = "attack damage rate"
+                            msg = "\"damage rate\" no longer refers to the rate of damage dealt, but rather the rate at which damage accumulates in the given cell type."
+                            msg += f"\n{elm[0]} had a rule affecting \"damage rate\" that has been replaced with \"attack damage rate\" to fit the new version."
+                            msg += "\nThis is because \"damage rate\" was found in the config file where \"attack damage rate\" is now used."
+                            self.show_warning(msg)
 
                         irow += 1
 
@@ -2087,8 +2098,10 @@ class Rules(QWidget):
         for s in self.substrates:
             self.response_l.append(s + " export")
         self.response_l.append("cycle entry")
-        self.response_l.append("damage rate")
+        self.response_l.append("attack damage rate")
         self.response_l.append("attack duration")
+        self.response_l.append("damage rate")
+        self.response_l.append("damage repair rate")
         for idx in range(6):  # TODO: hardwired
             self.response_l.append("exit from cycle phase " + str(idx))
 
@@ -2329,7 +2342,7 @@ class Rules(QWidget):
     #-------------------------
     def find_and_replace_rules_table(self, old_name, new_name, possible_superstrings):
         reserved_words_signals = ["contact with", "contact with live cell","contact with dead cell","contact with BM", "total attack time"]
-        reserved_words_behaviors = ["secretion target","cycle entry","damage rate","attack duration","migration speed","migration bias","migration persistence time","chemotactic response to","cell-cell adhesion","cell-cell adhesion elastic constant","adhesive affinity to","relative maximum adhesion distance","cell-cell repulsion","cell-BM adhesion","cell-BM repulsion","phagocytose apoptotic cell","phagocytose necrotic cell","phagocytose other dead cell","fuse to","transform to","immunogenicity to","cell attachment rate","cell detachment rate","maximum number of cell attachments"]
+        reserved_words_behaviors = ["secretion target","cycle entry","attack damage rate","attack duration","damage rate","damage repair rate","migration speed","migration bias","migration persistence time","chemotactic response to","cell-cell adhesion","cell-cell adhesion elastic constant","adhesive affinity to","relative maximum adhesion distance","cell-cell repulsion","cell-BM adhesion","cell-BM repulsion","phagocytose apoptotic cell","phagocytose necrotic cell","phagocytose other dead cell","fuse to","transform to","immunogenicity to","cell attachment rate","cell detachment rate","maximum number of cell attachments"]
         reserved_words_cycle_phases = [f"exit from cycle phase {i}" for i in range(6)]
         reserved_words = reserved_words_signals + reserved_words_behaviors + reserved_words_cycle_phases
         possible_superstrings += reserved_words


### PR DESCRIPTION
* populate_tree_cell_defs explicitly set all attack pars if interactions not found
* if-else blocks rather than try-except to manage backward compatibility for damage rate
* support "attack damage rate" as behavior
* support "damage repair rate" as behavior
* if config file "damage rate" is pre-1.14.0 and a rule governs "damage rate" update it to new version by changing behavior to "attack damage rate" and...
* issue warning to user if "damage rate" is behavior in rule and it config file is pre-1.14.0 as evidenced by "damage_rate" being within interactions and not in integrity