### PR TITLE
show names in plot dropdown rather than ids

### DIFF
--- a/bin/pyMCDS.py
+++ b/bin/pyMCDS.py
@@ -966,14 +966,7 @@ class pyMCDS:
             internal function to load the data from the PhysiCell output files
             into the pyMCDS instance.
         """
-        # file and path manipulation
-        xmlfile = xmlfile.replace('\\','/')
-        if (xmlfile.find('/') > -1) and (output_path == '.'):
-            ls_xmlfile = xmlfile.split('/')
-            xmlfile = ls_xmlfile.pop(-1)
-            output_path = '/'.join(ls_xmlfile)
-        output_path = pathlib.Path(output_path)
-        xmlpathfile = output_path / xmlfile
+        xmlpathfile, output_path = xmlfile_to_xmlpathfile(xmlfile, output_path)
 
         # read xml path/file
         # 20221027 juliano: d = xmltodict.parse(open('PhysiCell_settings.xml').read(), process_namespaces=True)
@@ -1308,3 +1301,13 @@ class pyMCDS:
         if self.verbose:
             print('done!')
         return MCDS
+
+def xmlfile_to_xmlpathfile(xmlfile, output_path):
+    xmlfile = xmlfile.replace('\\','/')
+    if (xmlfile.find('/') > -1) and (output_path == '.'):
+        ls_xmlfile = xmlfile.split('/')
+        xmlfile = ls_xmlfile.pop(-1)
+        output_path = '/'.join(ls_xmlfile)
+    output_path = pathlib.Path(output_path)
+    xmlpathfile = output_path / xmlfile
+    return xmlpathfile, output_path

--- a/bin/vis3D_tab.py
+++ b/bin/vis3D_tab.py
@@ -855,6 +855,8 @@ class Vis(VisBase, QWidget):
         print("    choice= ", choice)
         if len(choice) == 0:
             return
+        if choice in self.cell_scalar_human2mcds_dict.keys():
+            choice = self.cell_scalar_human2mcds_dict[choice]
 
         xml_files = glob.glob(self.output_dir+'/output*.xml')  # cross-platform OK?
         # print('xml_files = ',xml_files)
@@ -1601,6 +1603,8 @@ class Vis(VisBase, QWidget):
             cell_scalar_str = self.cell_scalar_combobox.currentText()
             if len(cell_scalar_str) == 0:
                 cell_scalar_str = 'cell_type'
+            if cell_scalar_str in self.cell_scalar_human2mcds_dict.keys():
+                cell_scalar_str = self.cell_scalar_human2mcds_dict[cell_scalar_str]
             # print("\n------- cell_scalar_str= ",cell_scalar_str)
             self.scalar_bar_cells.SetTitle(cell_scalar_str)
             # cell_type = mcds.data['discrete_cells']['data']['cell_type']

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -2593,25 +2593,25 @@ class VisBase():
         for cdname in self.celldef_tab.param_d.keys():
             cell_dict[self.celldef_tab.param_d[cdname]["ID"]] = cdname
 
-        substrate_scalar_prefixes = ['chemotactic_sensitivities_','secretion_rates_','uptake_rates_','saturation_densities_','net_export_rates_','internalized_total_substrates_','fraction_released_at_death_','fraction_transferred_when_ingested_']
+        substrate_scalar_prefixes = ['chemotactic_sensitivities','secretion_rates','uptake_rates','saturation_densities','net_export_rates','internalized_total_substrates','fraction_released_at_death','fraction_transferred_when_ingested']
         substrate_scalar_replace = {
-            'chemotactic_sensitivities_': lambda x: f'chemotactic response to {x}',
-            'secretion_rates_': lambda x:  f'(rate of) {x} secretion ',
-            'uptake_rates_': lambda x: f'(rate of) {x} uptake',
-            'saturation_densities_': lambda x: f'{x} secretion target',
-            'net_export_rates_': lambda x: f'(rate of) {x} export',
-            'internalized_total_substrates_': lambda x: f'(amount of) intracellular {x}',
-            'fraction_released_at_death_': lambda x: f'fraction released at death of {x}',
-            'fraction_transferred_when_ingested_': lambda x: f'fraction transferred when ingested of {x}'
+            'chemotactic_sensitivities': lambda x: f'chemotactic response to {x}',
+            'secretion_rates': lambda x:  f'(rate of) {x} secretion ',
+            'uptake_rates': lambda x: f'(rate of) {x} uptake',
+            'saturation_densities': lambda x: f'{x} secretion target',
+            'net_export_rates': lambda x: f'(rate of) {x} export',
+            'internalized_total_substrates': lambda x: f'(amount of) intracellular {x}',
+            'fraction_released_at_death': lambda x: f'fraction released at death of {x}',
+            'fraction_transferred_when_ingested': lambda x: f'fraction transferred when ingested of {x}'
         }
-        cell_scalar_prefixes = ['cell_adhesion_affinities_','live_phagocytosis_rates_','attack_rates_','immunogenicities_','fusion_rates_','transformation_rates_']
+        cell_scalar_prefixes = ['cell_adhesion_affinities','live_phagocytosis_rates','attack_rates','immunogenicities','fusion_rates','transformation_rates']
         cell_scalar_replace = {
-            'cell_adhesion_affinities_': lambda x: f'adhesive affinity to {x}',
-            'live_phagocytosis_rates_': lambda x: f'(rate of) phagocytose {x}',
-            'attack_rates_': lambda x: f'(rate of) attack {x}',
-            'immunogenicities_': lambda x: f'immunogenicity to {x}',
-            'fusion_rates_': lambda x: f'(rate of) fuse to {x}',
-            'transformation_rates_': lambda x: f'(rate of) transform to {x}'
+            'cell_adhesion_affinities': lambda x: f'adhesive affinity to {x}',
+            'live_phagocytosis_rates': lambda x: f'(rate of) phagocytose {x}',
+            'attack_rates': lambda x: f'(rate of) attack {x}',
+            'immunogenicities': lambda x: f'immunogenicity to {x}',
+            'fusion_rates': lambda x: f'(rate of) fuse to {x}',
+            'transformation_rates': lambda x: f'(rate of) transform to {x}'
         }
 
         for ind, scalar in enumerate(self.cell_scalars_l):
@@ -3094,6 +3094,8 @@ def find_name_in_dict(scalar, state_dict, prefixes, replace_dict, state_type='su
     for prefix in prefixes:
         if scalar.startswith(prefix):
             id = scalar.split(prefix)[1]
+            if id == '': # if there is only one substrate/celltype, no id is added to the name
+                id = '0'
             if id not in state_dict.keys():
                 if id not in find_name_in_dict.warned_ids:
                     print(f"WARNING: Could not find the name of the {state_type} with ID {id}.")

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -759,7 +759,7 @@ class VisBase():
         self.disable_cell_scalar_cb = False
         # self.cell_scalar_combobox = QComboBox()
         self.cell_scalar_combobox = ExtendedComboBox()
-        self.cell_scalar_combobox.setFixedWidth(270)
+        self.cell_scalar_combobox.setFixedWidth(320)
         self.cell_scalar_combobox.addItem("cell_type")
         # self.cell_scalar_combobox.currentIndexChanged.connect(self.cell_scalar_changed_cb)
 

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -284,7 +284,6 @@ class Vis(VisBase, QWidget):
         xml_file = os.path.join(self.output_dir, xml_file_root)
         # xml_file = os.path.join("tmpdir", xml_file_root)  # temporary hack
 
-        # cell_scalar_name = self.cell_scalar_combobox.currentText()
         if not Path(xml_file).is_file():
             print("ERROR: file not found",xml_file)
             return
@@ -518,7 +517,6 @@ class Vis(VisBase, QWidget):
             print("------ plot_svg(): error trying to parse ",full_fname)
             msgBox = QMessageBox()
             msgBox.setIcon(QMessageBox.Information)
-            # msg = "plot_cell_scalar(): error from mcds.get_cell_df()[" + cell_scalar_name + "]. You are probably trying to use out-of-date scalars. Resetting to .svg plots, so you will need to refresh the cell scalar dropdown combobox in the Plot tab."
             msg = "plot_svg(): error parsing "+full_fname+". You may have a partially written .svg file due to a canceled simulation."
             msgBox.setText(msg)
             msgBox.setStandardButtons(QMessageBox.Ok)
@@ -802,12 +800,12 @@ class Vis(VisBase, QWidget):
 
         xml_file_root = "output%08d.xml" % frame
         xml_file = os.path.join(self.output_dir, xml_file_root)
-        # xml_file = os.path.join("tmpdir", xml_file_root)  # temporary hack
-        cell_scalar_name = self.cell_scalar_combobox.currentText()
-        if cell_scalar_name in self.cell_scalar_human2mcds_dict.keys():
-            cell_scalar_name = self.cell_scalar_human2mcds_dict[cell_scalar_name]
+        cell_scalar_humanreadable_name = self.cell_scalar_combobox.currentText()
+        if cell_scalar_humanreadable_name in self.cell_scalar_human2mcds_dict.keys():
+            cell_scalar_mcds_name = self.cell_scalar_human2mcds_dict[cell_scalar_humanreadable_name]
+        else:
+            cell_scalar_mcds_name = cell_scalar_humanreadable_name
         cbar_name = self.cell_scalar_cbar_combobox.currentText()
-        # print(f"\n\n   >>>>--------- plot_cell_scalar(): xml_file={xml_file}, scalar={cell_scalar_name}, cbar={cbar_name}")
         if not Path(xml_file).is_file():
             print("ERROR: file not found",xml_file)
             return
@@ -816,13 +814,12 @@ class Vis(VisBase, QWidget):
         total_min = mcds.get_time()  # warning: can return float that's epsilon from integer value
     
         try:
-            cell_scalar = mcds.get_cell_df()[cell_scalar_name]
+            cell_scalar = mcds.get_cell_df()[cell_scalar_mcds_name]
         except:
-            print("vis_tab.py: plot_cell_scalar(): error performing mcds.get_cell_df()[cell_scalar_name]")
+            print("vis_tab.py: plot_cell_scalar(): error performing mcds.get_cell_df()[cell_scalar_mcds_name]")
             msgBox = QMessageBox()
             msgBox.setIcon(QMessageBox.Information)
-            # msg = "plot_cell_scalar(): error from mcds.get_cell_df()[" + cell_scalar_name + "]. You are probably trying to use out-of-date scalars. Resetting to .svg plots, so you will need to refresh the cell scalar dropdown combobox in the Plot tab."
-            msg = "plot_cell_scalar(): error from mcds.get_cell_df()[" + cell_scalar_name + "]. You may be trying to use out-of-date scalars. Please reset the 'full list' or 'partial'."
+            msg = "plot_cell_scalar(): error from mcds.get_cell_df()[" + cell_scalar_mcds_name + "]. You may be trying to use out-of-date scalars. Please reset the 'full list' or 'partial'."
             msgBox.setText(msg)
             msgBox.setStandardButtons(QMessageBox.Ok)
             msgBox.exec()
@@ -861,36 +858,33 @@ class Vis(VisBase, QWidget):
         # self.title_str += "   cells: " + svals[2] + "d, " + svals[4] + "h, " + svals[7][:-3] + "m"
         # self.title_str = "(" + str(frame) + ") Current time: " + str(total_min) + "m"
         
-        # print(cell_scalar_name, " - discrete: ", (cell_scalar % 1  == 0).all()) # Possible test if the variable is discrete or continuum variable (issue: in some time the continuum variable can be classified as discrete (example time=0))
-        
-        # if( cell_scalar_name == 'cell_type' or cell_scalar_name == 'current_phase'): discrete_variable = list(set(cell_scalar)) # It's a set of possible value of the variable
-        if cell_scalar_name in self.discrete_cell_scalars: 
+        if cell_scalar_mcds_name in self.discrete_cell_scalars: 
 
             self.discrete_variable_observed = self.discrete_variable_observed.union(set([int(i) for i in np.unique(cell_scalar)]))
 
-            if cell_scalar_name == "current_phase":   # and if "Fixed" range is checked
+            if cell_scalar_mcds_name == "current_phase":   # and if "Fixed" range is checked
                 self.discrete_variable = list(self.cycle_phases.keys())
                 names_observed = [self.cycle_phases[i] for i in sorted(list(self.discrete_variable_observed)) if i in self.cycle_phases.keys()]
 
-            elif cell_scalar_name == "cell_type":
+            elif cell_scalar_mcds_name == "cell_type":
                 # I'm not sure I should be calling this every time. But I'm also not sure about the life cycle of celltype_name
                 self.get_cell_types_from_config()
                 self.discrete_variable = list(range(len(self.celltype_name)))
                 names_observed = [self.celltype_name[i] for i in sorted(list(self.discrete_variable_observed)) if i < len(self.celltype_name)]
                 
-            elif cell_scalar_name == "cycle_model":
+            elif cell_scalar_mcds_name == "cycle_model":
                 self.discrete_variable = list(self.cycle_models.keys())
                 names_observed = [self.cycle_models[i] for i in sorted(list(self.discrete_variable_observed)) if i in self.cycle_models.keys()]
 
-            elif cell_scalar_name == "current_death_model":
+            elif cell_scalar_mcds_name == "current_death_model":
                 self.discrete_variable = [0,1]
                 names_observed = ["phase #%d" % i for i in sorted(list(self.discrete_variable_observed)) if i in [0,1]]
             
-            elif cell_scalar_name == "is_motile":
+            elif cell_scalar_mcds_name == "is_motile":
                 self.discrete_variable = [0,1]
                 names_observed = ["motile" if i == 1 else "stationnary" for i in sorted(list(self.discrete_variable_observed)) if i in [0,1]]
                 
-            elif cell_scalar_name == "dead":
+            elif cell_scalar_mcds_name == "dead":
                 self.discrete_variable = [0,1]
                 names_observed = ["dead" if i == 1 else "alive" for i in sorted(list(self.discrete_variable_observed)) if i in [0,1]]
             else:
@@ -983,7 +977,7 @@ class Vis(VisBase, QWidget):
                 self.cax2 = ax2_divider.append_axes("bottom", size="4%", pad="8%")
             self.cbar2 = self.figure.colorbar(cell_plot, ticks=None,cax=self.cax2, orientation="horizontal")
             self.cbar2.ax.tick_params(labelsize=self.fontsize)
-            self.cbar2.ax.set_xlabel(cell_scalar_name, fontsize=self.cbar_label_fontsize)
+            self.cbar2.ax.set_xlabel(cell_scalar_humanreadable_name, fontsize=self.cbar_label_fontsize)
    
         self.ax0.set_title(self.title_str, fontsize=self.title_fontsize)
         self.ax0.set_xlim(self.plot_xmin, self.plot_xmax)

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -804,6 +804,8 @@ class Vis(VisBase, QWidget):
         xml_file = os.path.join(self.output_dir, xml_file_root)
         # xml_file = os.path.join("tmpdir", xml_file_root)  # temporary hack
         cell_scalar_name = self.cell_scalar_combobox.currentText()
+        if cell_scalar_name in self.cell_scalar_human2mcds_dict.keys():
+            cell_scalar_name = self.cell_scalar_human2mcds_dict[cell_scalar_name]
         cbar_name = self.cell_scalar_cbar_combobox.currentText()
         # print(f"\n\n   >>>>--------- plot_cell_scalar(): xml_file={xml_file}, scalar={cell_scalar_name}, cbar={cbar_name}")
         if not Path(xml_file).is_file():


### PR DESCRIPTION
no more counting indices to figure out what internalized_total_substrate_37 means! Instead, use the xml to identify them. same for other mcds variables that are related to substrates.

same is done for cell types, but this (dangerously!) uses the studio to make the substitutions. very possible that users load up a different output folder and then things get weird. not broken, because we make sure the id exists. but still weird. but only if the user did a weird thing first (load a different output folder)