### PR TITLE
add icons for radiobuttons

### DIFF
--- a/bin/biwt_tab.py
+++ b/bin/biwt_tab.py
@@ -37,7 +37,7 @@ from PyQt5 import QtCore, QtGui
 from PyQt5.QtWidgets import QApplication,QWidget,QLineEdit,QHBoxLayout,QVBoxLayout,QRadioButton,QPushButton, QLabel,QCheckBox,QComboBox,QScrollArea,QGridLayout, QFileDialog, QButtonGroup, QSplitter, QSizePolicy, QSpinBox
 from PyQt5.QtGui import QIcon
 
-from studio_classes import QHLine, QVLine, QCheckBox_custom
+from studio_classes import QHLine, QVLine, QCheckBox_custom, QRadioButton_custom
 
 class GoBackButton(QPushButton):
     def __init__(self, parent, biwt):
@@ -128,8 +128,8 @@ class BioinformaticsWalkthroughWindow_SpatialQuery(BioinformaticsWalkthroughWind
         label = QLabel(s)
 
         self.yes_no_group = QButtonGroup()
-        self.yes = QRadioButton("Yes")
-        self.no = QRadioButton("No")
+        self.yes = QRadioButton_custom("Yes")
+        self.no = QRadioButton_custom("No")
         self.yes_no_group.addButton(self.yes,0)
         self.yes_no_group.addButton(self.no,1)
         self.yes_no_group.idToggled.connect(self.yn_toggled)
@@ -520,25 +520,25 @@ class BioinformaticsWalkthroughWindow_CellCounts(BioinformaticsWalkthroughWindow
         self.counts_button_group.idToggled.connect(self.counts_button_cb)
         counts_button_group_next_id = 0
 
-        self.use_counts_as_is_radio_button = QRadioButton("Use counts")
+        self.use_counts_as_is_radio_button = QRadioButton_custom("Use counts")
         self.use_counts_as_is_radio_button.setFixedWidth(counts_width)
         self.use_counts_as_is_radio_button.setChecked(True)
         self.counts_button_group.addButton(self.use_counts_as_is_radio_button,counts_button_group_next_id)
         counts_button_group_next_id += 1
 
-        self.use_props_radio_button = QRadioButton("Use proportions")
+        self.use_props_radio_button = QRadioButton_custom("Use proportions")
         self.use_props_radio_button.setFixedWidth(props_width)
         self.use_props_radio_button.setChecked(False)
         self.counts_button_group.addButton(self.use_props_radio_button,counts_button_group_next_id)
         counts_button_group_next_id += 1
 
-        self.use_confluence_radio_button = QRadioButton("Set confluence (%)")
+        self.use_confluence_radio_button = QRadioButton_custom("Set confluence (%)")
         self.use_confluence_radio_button.setFixedWidth(confluence_width)
         self.use_confluence_radio_button.setChecked(False)
         self.counts_button_group.addButton(self.use_confluence_radio_button,counts_button_group_next_id)
         counts_button_group_next_id += 1
 
-        self.use_manual_radio_button = QRadioButton("Set manually")
+        self.use_manual_radio_button = QRadioButton_custom("Set manually")
         self.use_manual_radio_button.setFixedWidth(manual_width)
         self.use_manual_radio_button.setChecked(False)
         self.counts_button_group.addButton(self.use_manual_radio_button,counts_button_group_next_id)

--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -49,7 +49,7 @@ from PyQt5.QtCore import Qt, QRect, QEvent
 from PyQt5 import QtCore, QtGui
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import QIcon, QFont, QStandardItemModel
-from studio_classes import QLabelSeparator, ExtendedCombo, QLineEdit_custom, OptionalDoubleValidator, HoverCheckBox, DoubleValidatorOpenInterval, DoubleValidatorWidgetBounded, AttackRateValidator
+from studio_classes import QLabelSeparator, ExtendedCombo, QLineEdit_custom, OptionalDoubleValidator, HoverCheckBox, DoubleValidatorOpenInterval, DoubleValidatorWidgetBounded, AttackRateValidator, QRadioButton_custom
 from rules_tab import create_reserved_words, find_and_replace_rule_cell
 # from PyQt5.QtCore import Qt
 # from cell_def_custom_data import CustomData
@@ -811,11 +811,11 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         hbox = QHBoxLayout()
         hbox.setSpacing(0)
         hbox.setContentsMargins(0, 0, 0, 0)
-        self.cycle_rb1 = QRadioButton("transition rate(s)      ")
+        self.cycle_rb1 = QRadioButton_custom("transition rate(s)      ")
         self.cycle_rb1.toggled.connect(self.cycle_phase_transition_cb)
         hbox.addWidget(self.cycle_rb1)
 
-        self.cycle_rb2 = QRadioButton("duration(s)")
+        self.cycle_rb2 = QRadioButton_custom("duration(s)")
         self.cycle_rb2.toggled.connect(self.cycle_phase_transition_cb)
         hbox.addWidget(self.cycle_rb2)
 
@@ -1761,10 +1761,10 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         hbox.setSpacing(0)
         hbox.setContentsMargins(0, 0, 0, 0)
 
-        self.apoptosis_rb1 = QRadioButton("transition rate     ", self)  # OMG, leave "self" for QButtonGroup
+        self.apoptosis_rb1 = QRadioButton_custom("transition rate     ", parent=self)  # OMG, leave "self" for QButtonGroup
         self.apoptosis_rb1.toggled.connect(self.apoptosis_phase_transition_cb)
 
-        self.apoptosis_rb2 = QRadioButton("duration", self)
+        self.apoptosis_rb2 = QRadioButton_custom("duration", parent=self)
         self.apoptosis_rb2.toggled.connect(self.apoptosis_phase_transition_cb)
 
         hbox.addWidget(self.apoptosis_rb1)
@@ -1949,10 +1949,10 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         hbox.setSpacing(0)
         hbox.setContentsMargins(0, 0, 0, 0)
 
-        self.necrosis_rb1 = QRadioButton("transition rate     ", self)  # OMG, leave "self" for QButtonGroup
+        self.necrosis_rb1 = QRadioButton_custom("transition rate     ", parent=self)  # OMG, leave "self" for QButtonGroup
         self.necrosis_rb1.toggled.connect(self.necrosis_phase_transition_cb)
 
-        self.necrosis_rb2 = QRadioButton("duration", self)
+        self.necrosis_rb2 = QRadioButton_custom("duration", parent=self)
         self.necrosis_rb2.toggled.connect(self.necrosis_phase_transition_cb)
 
         hbox.addWidget(self.necrosis_rb1)
@@ -2806,10 +2806,10 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.motility_substrate_dropdown.currentIndexChanged.connect(self.motility_substrate_changed_cb)  # beware: will be triggered on a ".clear" too
         # self.motility_substrate_dropdown.addItem("oxygen")
 
-        self.chemotaxis_direction_towards = QRadioButton("towards")
+        self.chemotaxis_direction_towards = QRadioButton_custom("towards")
         self.chemotaxis_direction_towards.clicked.connect(self.chemotaxis_direction_cb)
 
-        self.chemotaxis_direction_against = QRadioButton("against")
+        self.chemotaxis_direction_against = QRadioButton_custom("against")
         self.chemotaxis_direction_against.clicked.connect(self.chemotaxis_direction_cb)
 
         hbox = QHBoxLayout()

--- a/bin/config_tab.py
+++ b/bin/config_tab.py
@@ -16,7 +16,7 @@ from PyQt5 import QtCore, QtGui
 from PyQt5.QtWidgets import QFrame,QApplication,QWidget,QTabWidget,QLineEdit,QHBoxLayout,QVBoxLayout,QRadioButton,QPushButton, QLabel,QCheckBox,QComboBox,QScrollArea,QGridLayout, QFileDialog,QSpinBox,QDoubleSpinBox, QButtonGroup    # , QMessageBox
 # from PyQt5.QtWidgets import QMessageBox
 
-from studio_classes import QLabelSeparator, QLineEdit_custom, QCheckBox_custom
+from studio_classes import QLabelSeparator, QLineEdit_custom, QCheckBox_custom, QRadioButton_custom
 from studio_functions import style_sheet_template
 
 class RandomSeedIntValidator(QtGui.QValidator):
@@ -67,28 +67,6 @@ class Config(QWidget):
         # self.tab = QWidget()
         # self.tabs.resize(200,5)
 
-        radiobutton_style = """
-            QRadioButton {
-                spacing: 10px; /* Space between indicator and text */
-                color: black; /* Text color */
-            }
-
-            QRadioButton::indicator {
-                width: 12px; /* Indicator size */
-                height: 12px;
-                border-radius: 6px; /* Rounded indicator */
-            }
-
-            QRadioButton::indicator:unchecked {
-                border: 1px solid gray; /* Border when unchecked */
-            }
-
-            QRadioButton::indicator:checked {
-                background-color: rgb(21,96,209); /* Filled color when checked */
-                border: 1px solid black;
-            }
-                """
-        
         #-------------------------------------------
         label_width = 110
         domain_value_width = 100
@@ -351,12 +329,12 @@ class Config(QWidget):
         self.random_seed_gp.idToggled.connect(self.random_seed_gp_cb)
         random_seed_gp_next_id = 0
 
-        self.random_seed_random_button = QRadioButton("system clock",styleSheet=radiobutton_style)
+        self.random_seed_random_button = QRadioButton_custom("system clock")
         self.random_seed_gp.addButton(self.random_seed_random_button, random_seed_gp_next_id)
         hbox.addWidget(self.random_seed_random_button)
         random_seed_gp_next_id += 1
 
-        self.random_seed_integer_button = QRadioButton("integer \u2192 ",styleSheet=radiobutton_style)
+        self.random_seed_integer_button = QRadioButton_custom("integer \u2192")
         self.random_seed_gp.addButton(self.random_seed_integer_button, random_seed_gp_next_id)
         hbox.addWidget(self.random_seed_integer_button)
         random_seed_gp_next_id += 1

--- a/bin/icon/RadioButtonChecked.svg
+++ b/bin/icon/RadioButtonChecked.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 270.91 270.91">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #0091d1;
+      }
+
+      .cls-1, .cls-2 {
+        stroke-width: 0px;
+      }
+
+      .cls-2 {
+        fill: #fff;
+      }
+    </style>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <g>
+      <circle class="cls-1" cx="135.46" cy="135.46" r="135.46"/>
+      <circle class="cls-2" cx="135.46" cy="135.46" r="61.2"/>
+    </g>
+  </g>
+</svg>

--- a/bin/icon/RadioButtonUnchecked.svg
+++ b/bin/icon/RadioButtonUnchecked.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250.8 250.8">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #fff;
+        stroke: #939598;
+        stroke-miterlimit: 10;
+        stroke-width: 6px;
+      }
+    </style>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <circle class="cls-1" cx="125.4" cy="125.4" r="122.4"/>
+  </g>
+</svg>

--- a/bin/studio_classes.py
+++ b/bin/studio_classes.py
@@ -2,7 +2,7 @@ import sys
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QEvent
-from PyQt5.QtWidgets import QFrame, QCheckBox, QWidget, QLineEdit, QWidget, QComboBox, QLabel, QCompleter, QToolTip
+from PyQt5.QtWidgets import QFrame, QCheckBox, QWidget, QLineEdit, QWidget, QComboBox, QLabel, QCompleter, QToolTip, QRadioButton
 from PyQt5.QtGui import QValidator, QDoubleValidator
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QEvent
 
@@ -108,6 +108,27 @@ class QLineEdit_custom(QLineEdit):
                 background-color:gray;
             }
             """
+
+radiobutton_style = """
+QRadioButton {
+    spacing: 4px; /* Space between indicator and text */
+    padding-left: 4px;
+}
+QRadioButton::indicator {
+    width: 12;
+    height: 12;
+}
+QRadioButton::indicator:unchecked {
+    image: url(bin/icon/RadioButtonUnchecked.svg);
+}
+QRadioButton::indicator:checked {
+    image: url(bin/icon/RadioButtonChecked.svg);
+}
+"""
+class QRadioButton_custom(QRadioButton):
+    def __init__(self, text, styleSheet=radiobutton_style, **kwargs):
+        super(QRadioButton, self).__init__(text, **kwargs)
+        self.setStyleSheet(styleSheet)
 
 class ExtendedCombo( QComboBox ):
     def __init__( self,  parent = None):

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -66,7 +66,7 @@ from phenotypeSummary import PhenotypeWindow
 
 from populate_tree_cell_defs import populate_tree_cell_defs
 
-from studio_classes import QCheckBox_custom
+from studio_classes import QCheckBox_custom, QRadioButton_custom
 from pyMCDS import xmlfile_to_xmlpathfile
 
 #---------------------------
@@ -722,10 +722,10 @@ class VisBase():
         self.cells_hbox.addWidget(self.cells_checkbox) 
 
         # Need to create the following regardless of 2D/3D
-        self.cells_svg_rb = QRadioButton(".svg")
+        self.cells_svg_rb = QRadioButton_custom(".svg")
         self.cells_svg_rb.setChecked(True)
 
-        self.cells_mat_rb = QRadioButton(".mat")
+        self.cells_mat_rb = QRadioButton_custom(".mat")
         # self.cell_edge_checkbox = QCheckBox_custom('edge')
         
         if not self.model3D_flag:  # 2D vis
@@ -1417,7 +1417,7 @@ class VisBase():
             self.vbox.removeWidget(self.stretch_widget) #removes the placeholder for the "stretcher widget" to place it at the bottom
             self.cells_hbox.removeItem(self.hz_stretch_item_1) #same as above
 
-            self.cells_physiboss_rb = QRadioButton("physiboss")
+            self.cells_physiboss_rb = QRadioButton_custom("physiboss")
             self.cells_physiboss_rb.setChecked(False)
             self.cells_physiboss_rb.clicked.connect(self.cells_svg_mat_cb)
             self.cells_hbox.addWidget(self.cells_physiboss_rb)


### PR DESCRIPTION
this fixes the bug that the radio buttons do not render correctly on the config tab when launching studio.

set a standard stylesheet for all radio buttons throughout. updated all radio buttons to be instances of `QRadioButton_custom` and use this stylesheet by default.