### PR TITLE
Better warnings on fast rates

### DIFF
--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -48,8 +48,9 @@ import xml.etree.ElementTree as ET  # https://docs.python.org/2/library/xml.etre
 from PyQt5.QtCore import Qt, QRect, QEvent
 from PyQt5 import QtCore, QtGui
 from PyQt5.QtWidgets import *
+from PyQt5.QtSvg import QSvgWidget
 from PyQt5.QtGui import QIcon, QFont, QStandardItemModel
-from studio_classes import QLabelSeparator, ExtendedCombo, QLineEdit_custom, OptionalDoubleValidator, HoverCheckBox, DoubleValidatorOpenInterval, DoubleValidatorWidgetBounded, AttackRateValidator, QRadioButton_custom
+from studio_classes import QLabelSeparator, ExtendedCombo, QLineEdit_custom, OptionalDoubleValidator, HoverCheckBox, DoubleValidatorOpenInterval, DoubleValidatorWidgetBounded, AttackRateValidator, QRadioButton_custom, HoverWarning
 from rules_tab import create_reserved_words, find_and_replace_rule_cell
 from sbml_intra import SBML_ODEs
 # from PyQt5.QtCore import Qt
@@ -174,7 +175,7 @@ class CellDef(QWidget):
 
         self.new_cell_def_count = 0
         self.label_width = 210
-        self.units_width = 110
+        self.units_width = 35
         self.idx_current_cell_def = 1    # 1-offset for XML (ElementTree, ET)
         self.xml_root = None
         self.config_path = None
@@ -3033,6 +3034,9 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         units.setFixedWidth(self.units_width)
         units.setAlignment(QtCore.Qt.AlignLeft)
         glayout.addWidget(units, idr,3, 1,1) # w, row, column, rowspan, colspan
+
+        self.apoptotic_phagocytosis_rate_fast_label = HoverWarning("")
+        glayout.addWidget(self.apoptotic_phagocytosis_rate_fast_label, idr, 4, 1, 1) # w, row, column, rowspan, colspan
         
         label = QLabel("necrotic phagocytosis rate")
         label.setFixedWidth(self.label_width)
@@ -3050,6 +3054,9 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         units.setAlignment(QtCore.Qt.AlignLeft)
         glayout.addWidget(units, idr,3, 1,1) # w, row, column, rowspan, colspan
 
+        self.necrotic_phagocytosis_rate_fast_label = HoverWarning("")
+        glayout.addWidget(self.necrotic_phagocytosis_rate_fast_label, idr, 4, 1, 1) # w, row, column, rowspan, colspan
+
         label = QLabel("other dead phagocytosis rate")
         label.setFixedWidth(self.label_width)
         label.setAlignment(QtCore.Qt.AlignRight)
@@ -3065,6 +3072,9 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         units.setFixedWidth(self.units_width)
         units.setAlignment(QtCore.Qt.AlignLeft)
         glayout.addWidget(units, idr,3, 1,1) # w, row, column, rowspan, colspan
+
+        self.other_dead_phagocytosis_rate_fast_label = HoverWarning("")
+        glayout.addWidget(self.other_dead_phagocytosis_rate_fast_label, idr, 4, 1, 1) # w, row, column, rowspan, colspan
 
         #------
         label = QLabel("live phagocytosis rate")
@@ -3088,6 +3098,9 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         units.setAlignment(QtCore.Qt.AlignLeft)
         glayout.addWidget(units, idr,3, 1,1) # w, row, column, rowspan, colspan
 
+        self.live_phagocytosis_rate_fast_label = HoverWarning("")
+        glayout.addWidget(self.live_phagocytosis_rate_fast_label, idr, 4, 1, 1) # w, row, column, rowspan, colspan
+
         #------
         label = QLabel("attack rate")
         label.setFixedWidth(self.label_width)
@@ -3102,10 +3115,11 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
 
         self.attack_rate = QLineEdit_custom()
         self.attack_rate.textChanged.connect(self.attack_rate_changed)
-        if hasattr(self, 'immunogenicity_dropdown'): # then immunogenicity has been implemented
-            validator = AttackRateValidator(self)
-        else:
-            validator = DoubleValidatorWidgetBounded(bottom=0.0, top=self.config_tab.mechanics_dt, top_transform=lambda x: 1/x)
+        # if hasattr(self, 'immunogenicity_dropdown'): # then immunogenicity has been implemented
+        #     validator = AttackRateValidator(self)
+        # else:
+        #     validator = DoubleValidatorWidgetBounded(bottom=0.0, top=self.config_tab.mechanics_dt, top_transform=lambda x: 1/x)
+        validator = QtGui.QDoubleValidator(bottom=0.0) # no longer want to highlight the box red if rate is too high (just show warning (!) )
         self.attack_rate.setValidator(validator)
         glayout.addWidget(self.attack_rate , idr,2, 1,1) # w, row, column, rowspan, colspan
 
@@ -3114,11 +3128,8 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         units.setAlignment(QtCore.Qt.AlignLeft)
         glayout.addWidget(units, idr,3, 1,1) # w, row, column, rowspan, colspan
 
-        idr += 1
-        self.attack_rate_fast_label = QLabel("")
-        self.attack_rate_fast_label.setStyleSheet("color: red")
-        glayout.addWidget(self.attack_rate_fast_label, idr,0, 1,4) # w, row, column, rowspan, colspan
-
+        self.attack_rate_fast_label = HoverWarning("")
+        glayout.addWidget(self.attack_rate_fast_label, idr, 4, 1, 1) # w, row, column, rowspan, colspan
 
         #------
         label = QLabel("attack damage rate")
@@ -3176,6 +3187,9 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         units.setAlignment(QtCore.Qt.AlignLeft)
         glayout.addWidget(units, idr,3, 1,1) # w, row, column, rowspan, colspan
 
+        self.fusion_rate_fast_label = HoverWarning("")
+        glayout.addWidget(self.fusion_rate_fast_label, idr, 4, 1, 1) # w, row, column, rowspan, colspan
+
         #------
         label = QLabel("transformation rate")
         label.setFixedWidth(self.label_width)
@@ -3197,6 +3211,9 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         units.setFixedWidth(self.units_width)
         units.setAlignment(QtCore.Qt.AlignLeft)
         glayout.addWidget(units, idr,3, 1,1) # w, row, column, rowspan, colspan
+
+        self.transformation_rate_fast_label = HoverWarning("")
+        glayout.addWidget(self.transformation_rate_fast_label, idr, 4, 1, 1) # w, row, column, rowspan, colspan
 
         #------
         label = QLabel("damage rate")
@@ -3293,18 +3310,53 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.param_d[self.current_cell_def]['cell_adhesion_affinity'][self.cell_adhesion_affinity_celltype] = text
 
     #--------------------------------------------------------
+    def is_dt_set(self, label, time_step, dt_text):
+        if dt_text != "" and float(dt_text) != 0:
+            return True
+        label.show_warning()
+        label.setHoverText(f"WARNING: Current {time_step} is 0 (or unset). Make sure to set that value > 0.")
+        return False
+
+    def check_rate_too_fast(self, text, label, time_step="mechanics_dt"):
+        if text == "":
+            return
+
+        if time_step == "diffusion_dt":
+            dt_text = self.config_tab.diffusion_dt.text()
+        elif time_step == "mechanics_dt":
+            dt_text = self.config_tab.mechanics_dt.text()
+        elif time_step == "phenotype_dt":
+            dt_text = self.config_tab.phenotype_dt.text()
+
+        if self.is_dt_set(label, time_step, dt_text) == False:
+            return
+
+        rate = float(text)
+        dt = float(dt_text)
+        max_val = 1/dt
+        prob = rate * dt
+        if prob > 1:
+            label.show_warning()
+            label.setHoverText(f"WARNING: A rate > 1/{time_step} is instantaneous. May as well set to {max_val}.")
+        else:
+            label.no_warning()
+
     def apoptotic_phagocytosis_rate_changed(self,text):
         self.param_d[self.current_cell_def]['apoptotic_phagocytosis_rate'] = text
+        self.check_rate_too_fast(text, self.apoptotic_phagocytosis_rate_fast_label)
     #--------------------------------------------------------
     def necrotic_phagocytosis_rate_changed(self,text):
         self.param_d[self.current_cell_def]['necrotic_phagocytosis_rate'] = text
+        self.check_rate_too_fast(text, self.necrotic_phagocytosis_rate_fast_label)
     #--------------------------------------------------------
     def other_dead_phagocytosis_rate_changed(self,text):
         self.param_d[self.current_cell_def]['other_dead_phagocytosis_rate'] = text
+        self.check_rate_too_fast(text, self.other_dead_phagocytosis_rate_fast_label)
     #--------------------------------------------------------
     def live_phagocytosis_rate_changed(self,text):
         celltype_name = self.live_phagocytosis_dropdown.currentText()
         self.param_d[self.current_cell_def]['live_phagocytosis_rate'][celltype_name] = text
+        self.check_rate_too_fast(text, self.live_phagocytosis_rate_fast_label)
     #--------------------------------------------------------
     def attack_rate_changed(self,text):
         celltype_name = self.attack_rate_dropdown.currentText()
@@ -3313,12 +3365,12 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         if text == "":
             return
         
-        if self.config_tab.mechanics_dt.text() == "" or float(self.config_tab.mechanics_dt.text()) == 0:
-            self.attack_rate_fast_label.setText(f"WARNING: Current mechanics_dt is 0 (or unset). Make sure to set that value > 0.")
+        mech_dt_str = self.config_tab.mechanics_dt.text()
+        if self.is_dt_set(self.attack_rate_fast_label, "mechanics_dt", mech_dt_str) == False:
             return
         
+        mech_dt = float(mech_dt_str)
         attack_rate = float(text) 
-        mech_dt = float(self.config_tab.mechanics_dt.text())
         max_val = 1/mech_dt
         attack_prob = attack_rate * mech_dt
         if "immunogenicity" in self.param_d[self.current_cell_def].keys():
@@ -3328,10 +3380,11 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             denom = "(immunogenicity * mechanics_dt)"
         else:  
             denom = "mechanics_dt"
-        if attack_prob > 1: # attack_rate * dt > 1 <==> attack_rate > 1/dt
-            self.attack_rate_fast_label.setText(f"WARNING: An attack rate > 1/{denom} is instantaneous. May as well set to {max_val}.")
+        if attack_prob > 1:
+            self.attack_rate_fast_label.show_warning()
+            self.attack_rate_fast_label.setHoverText(f"WARNING: An attack rate > 1/{denom} is instantaneous. May as well set to {max_val}.")
         else:
-            self.attack_rate_fast_label.setText("")
+            self.attack_rate_fast_label.no_warning()
     #--------------------------------------------------------
     def attack_damage_rate_changed(self,text):
         self.param_d[self.current_cell_def]['attack_damage_rate'] = text
@@ -3342,10 +3395,12 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
     def fusion_rate_changed(self,text):
         celltype_name = self.fusion_rate_dropdown.currentText()
         self.param_d[self.current_cell_def]['fusion_rate'][celltype_name] = text
+        self.check_rate_too_fast(text, self.fusion_rate_fast_label)
     #--------------------------------------------------------
     def transformation_rate_changed(self,text):
         celltype_name = self.cell_transformation_dropdown.currentText()
         self.param_d[self.current_cell_def]['transformation_rate'][celltype_name] = text
+        self.check_rate_too_fast(text, self.transformation_rate_fast_label)
     #--------------------------------------------------------
     def damage_rate_changed(self,text):
         self.param_d[self.current_cell_def]['damage_rate'] = text

--- a/bin/images/warning.svg
+++ b/bin/images/warning.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #ed1c24;
+      }
+
+      .cls-1, .cls-2 {
+        stroke-width: 0px;
+      }
+
+      .cls-2 {
+        fill: #fff;
+      }
+    </style>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <circle class="cls-1" cx="540" cy="540" r="540"/>
+    <circle class="cls-2" cx="540" cy="540" r="468"/>
+    <path class="cls-1" d="M427.92,865.7c0-66.37,46.33-113.96,112.7-113.96s110.2,47.59,111.45,113.96c0,65.12-43.83,113.96-111.45,113.96s-112.7-48.84-112.7-113.96ZM469.25,689.13l-28.8-567.28h199.11l-27.55,567.28h-142.76Z"/>
+  </g>
+</svg>

--- a/bin/populate_tree_cell_defs.py
+++ b/bin/populate_tree_cell_defs.py
@@ -227,114 +227,114 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
                     sval = rate.text
                     if (rate.attrib['start_index'] == "0"): 
                         if (rate.attrib['end_index'] == "0"): #  Must be 'live'
-                            logging.debug(f'--  cycle_live_trate00 {sval}')
-                            cell_def_tab.param_d[cell_def_name]['cycle_live_trate00'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_live_duration00'] = invertf2s(sval) # invert
+                            logging.debug(f'--  cycle_live_00_trate {sval}')
+                            cell_def_tab.param_d[cell_def_name]['cycle_live_00_trate'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_live_00_duration'] = invertf2s(sval) # invert
                             if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_live_trate00_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_live_duration00_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_live_00_fixed_trate'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_live_00_fixed_duration'] = True
                         elif (rate.attrib['end_index'] == "1"): 
                             if cycle_code == 0: #'advanced Ki67'
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate01'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration01'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate01_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration01_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_fixed_duration'] = True
                             elif cycle_code == 1: # 'basic Ki67'
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate01'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration01'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate01_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration01_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_fixed_duration'] = True
                             elif cycle_code == 2: # 'flow cytometry'
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate01'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration01'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate01_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration01_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_fixed_duration'] = True
                             elif cycle_code == 6: # 'flow cytometry separated'
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate01'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration01'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate01_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration01_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_fixed_duration'] = True
                             elif cycle_code == 7: # 'cycling quiescent'
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate01'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration01'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate01_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration01_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_fixed_duration'] = True
 
                     elif (rate.attrib['start_index'] == "1"):
                         if (rate.attrib['end_index'] == "0"):
                             if cycle_code == 1: # 'basic Ki67'
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate10'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration10'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate10_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration10_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_fixed_duration'] = True
                             elif cycle_code == 7: # 'cycling quiescent'
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate10'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration10'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate10_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration10_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_fixed_duration'] = True
                         elif (rate.attrib['end_index'] == "2"):
                             if cycle_code == 0: #'advanced Ki67'
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate12'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration12'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate12_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration12_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_fixed_duration'] = True
                             elif cycle_code == 2: # 'flow cytometry'
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate12'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration12'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate12_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration12_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_fixed_duration'] = True
                             elif cycle_code == 6: # 'flow cytometry separated'
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate12'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration12'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate12_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration12_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_fixed_duration'] = True
                             elif cycle_code == 7: # 'cycling quiescent'
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate12'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration12'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_12_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_12_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate12_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration12_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_12_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_quiescent_12_fixed_duration'] = True
 
                     elif (rate.attrib['start_index'] == "2"):
                         if (rate.attrib['end_index'] == "0"):
                             if cycle_code == 0: #'advanced Ki67'
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate20'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration20'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate20_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration20_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_fixed_duration'] = True
                             elif cycle_code == 2: # 'flow cytometry'
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate20'] = sval
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration20'] = invertf2s(sval) # invert
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_trate'] = sval
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_duration'] = invertf2s(sval) # invert
                                 if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate20_fixed'] = True
-                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration20_fixed'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_fixed_trate'] = True
+                                    cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_fixed_duration'] = True
 
                         elif (rate.attrib['end_index'] == "3"):
                             # if cycle_code == 6: # 'flow cytometry separated'
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate23'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration23'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_trate'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_duration'] = invertf2s(sval) # invert
                             if (rate.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate23_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration23_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_fixed_trate'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_fixed_duration'] = True
 
                     elif (rate.attrib['start_index'] == "3") and (rate.attrib['end_index'] == "0"):
-                        # cell_def_tab.cycle_flowcytosep_trate30.setText(rate.text)
-                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate30'] = rate.text
-                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration30'] = invertf2s(sval) # invert
+                        # cell_def_tab.cycle_flowcytosep_30_trate.setText(rate.text)
+                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_trate'] = rate.text
+                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_duration'] = invertf2s(sval) # invert
                         if (rate.attrib['fixed_duration'].lower() == "true"): 
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate30_fixed'] = True
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration30_fixed'] = True
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_fixed_trate'] = True
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_fixed_duration'] = True
 
 
             # template.xml:
@@ -376,104 +376,104 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
 
                     if (pd.attrib['index'] == "0"): 
                         if cycle_code == 0: #'advanced Ki67'
-                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration01'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate01'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration01_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate01_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_01_fixed_trate'] = True
                         elif cycle_code == 1: # 'basic Ki67'
-                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration01'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate01'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration01_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate01_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_01_fixed_trate'] = True
                         elif cycle_code == 2: # 'flow cytometry'
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration01'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate01'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration01_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate01_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_01_fixed_trate'] = True
                         elif cycle_code == 5: # 'live'
                             logging.debug(f'------------ for live: sval for phase duration= {sval}')
-                            cell_def_tab.param_d[cell_def_name]['cycle_live_duration00'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_live_trate00'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_live_00_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_live_00_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_live_duration00_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_live_trate00_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_live_00_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_live_00_fixed_trate'] = True
                         elif cycle_code == 6: # 'flow cytometry separated'
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration01'] = sval
-                            # cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate01'] = str(1.0/float(sval)) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_duration'] = sval
+                            # cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_trate'] = str(1.0/float(sval)) # invert
                             # val3.setText(f'{fval:.{number_of_decimals}f}')
-                            # cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate01'] = f'{1.0/float(sval):{num_dec}f}' # invert
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate01'] = invertf2s(sval)
+                            # cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_trate'] = f'{1.0/float(sval):{num_dec}f}' # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_trate'] = invertf2s(sval)
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration01_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate01_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_01_fixed_trate'] = True
                         elif cycle_code == 7: # 'cycling quiescent'
-                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration01'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate01'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration01_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate01_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_01_fixed_trate'] = True
 
                     elif (pd.attrib['index'] == "1"):
                         if cycle_code == 0: #'advanced Ki67'
-                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration12'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate12'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration12_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate12_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_12_fixed_trate'] = True
                         elif cycle_code == 1: #'basic Ki67'
-                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration10'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate10'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_duration10_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_trate10_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_Ki67_10_fixed_trate'] = True
                         elif cycle_code == 2: # 'flow cytometry'
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration12'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate12'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration12_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate12_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_12_fixed_trate'] = True
                         elif cycle_code == 6: # 'flow cytometry separated'
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration12'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate12'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration12_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate12_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_12_fixed_trate'] = True
                         elif cycle_code == 7: # 'cycling quiescent'
-                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration10'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate10'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_duration10_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_trate10_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_quiescent_10_fixed_trate'] = True
 
                     elif (pd.attrib['index'] == "2"):
                         if cycle_code == 0: #'advanced Ki67'
-                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration20'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate20'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_duration20_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_trate20_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_advancedKi67_20_fixed_trate'] = True
                         elif cycle_code == 2: # 'flow cytometry'
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration20'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate20'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_duration20_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_trate20_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcyto_20_fixed_trate'] = True
                         elif cycle_code == 6: # 'flow cytometry separated'
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration23'] = sval
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate23'] = invertf2s(sval) # invert
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_duration'] = sval
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_trate'] = invertf2s(sval) # invert
                             if (pd.attrib['fixed_duration'].lower() == "true"): 
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration23_fixed'] = True
-                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate23_fixed'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_fixed_duration'] = True
+                                cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_23_fixed_trate'] = True
 
                     elif (pd.attrib['index'] == "3"):
-                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration30'] = sval
-                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate30'] = invertf2s(sval) # invert
+                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_duration'] = sval
+                        cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_trate'] = invertf2s(sval) # invert
                         if (pd.attrib['fixed_duration'].lower() == "true"): 
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_duration30_fixed'] = True
-                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_trate30_fixed'] = True
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_fixed_duration'] = True
+                            cell_def_tab.param_d[cell_def_name]['cycle_flowcytosep_30_fixed_trate'] = True
 
 
             # rf. microenv:
@@ -484,7 +484,7 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
             # ---------  cycle (live)
             # cell_def_tab.float0.value = float(uep.find('.//cell_definition[1]//phenotype//cycle//phase_transition_rates//rate[1]').text)
 
-            # cell_def_tab.param_d[cell_def_name]['cycle_live_duration00'] = default_sval  # rwh - WHY?!
+            # cell_def_tab.param_d[cell_def_name]['cycle_live_00_duration'] = default_sval  # rwh - WHY?!
 
             # ---------  death 
             logging.debug(f'\n===== populate_tree():  death')
@@ -536,20 +536,20 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
 
             # rwh: init death params to default? - yipeee, don't need now?
             # cell_def_tab.param_d[cell_def_name]['apoptosis_duration_flag'] = False
-            # cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_duration"] = "0.0"
-            # cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_fixed"] = False
-            # cell_def_tab.param_d[cell_def_name]["apoptosis_trate01"] = "0.0"
-            # cell_def_tab.param_d[cell_def_name]["apoptosis_trate01_fixed"] = False
+            # cell_def_tab.param_d[cell_def_name]["apoptosis_01_duration"] = "0.0"
+            # cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_duration"] = False
+            # cell_def_tab.param_d[cell_def_name]["apoptosis_01_trate"] = "0.0"
+            # cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_trate"] = False
 
             # cell_def_tab.param_d[cell_def_name]['necrosis_duration_flag'] = False
-            # cell_def_tab.param_d[cell_def_name]["necrosis_phase0_duration"] = "0.0"
-            # cell_def_tab.param_d[cell_def_name]["necrosis_phase0_fixed"] = False
-            # cell_def_tab.param_d[cell_def_name]["necrosis_phase1_duration"] = "0.0"
-            # cell_def_tab.param_d[cell_def_name]["necrosis_phase1_fixed"] = False
-            # cell_def_tab.param_d[cell_def_name]["necrosis_trate01"] = "0.0"
-            # cell_def_tab.param_d[cell_def_name]["necrosis_trate01_fixed"] = False
-            # cell_def_tab.param_d[cell_def_name]["necrosis_trate12"] = "0.0"
-            # cell_def_tab.param_d[cell_def_name]["necrosis_trate12_fixed"] = False
+            # cell_def_tab.param_d[cell_def_name]["necrosis_01_duration"] = "0.0"
+            # cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_duration"] = False
+            # cell_def_tab.param_d[cell_def_name]["necrosis_12_duration"] = "0.0"
+            # cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_duration"] = False
+            # cell_def_tab.param_d[cell_def_name]["necrosis_01_trate"] = "0.0"
+            # cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_trate"] = False
+            # cell_def_tab.param_d[cell_def_name]["necrosis_12_trate"] = "0.0"
+            # cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_trate"] = False
 
             # uep = cell_def_tab.xml_root.find('.//microenvironment_setup')  # find unique entry point
             death_uep = uep.find(".//cell_definition[" + str(idx) + "]//phenotype//death")
@@ -581,15 +581,15 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
                             logging.debug(f'index= {pd.attrib["index"]}')
                             if  pd.attrib['index'] == "0":
                     # 			<duration index="0" fixed_duration="true">86400.1</duration>
-                                cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_duration"] = pd.text
+                                cell_def_tab.param_d[cell_def_name]["apoptosis_01_duration"] = pd.text
                                 # print("populate(): apop phase0 duration= ",pd.text)  # rwh
-                                cell_def_tab.param_d[cell_def_name]["apoptosis_trate01"] = invertf2s(pd.text)
+                                cell_def_tab.param_d[cell_def_name]["apoptosis_01_trate"] = invertf2s(pd.text)
                                 if  pd.attrib['fixed_duration'].lower() == "true":
-                                    cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_fixed"] = True
-                                    cell_def_tab.param_d[cell_def_name]["apoptosis_trate01_fixed"] = True
+                                    cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_duration"] = True
+                                    cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_trate"] = True
                                 else:
-                                    cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_fixed"] = False
-                                    cell_def_tab.param_d[cell_def_name]["apoptosis_trate01_fixed"] = False
+                                    cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_duration"] = False
+                                    cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_trate"] = False
 
                     # 			<duration index="1" fixed_duration="true">86400.1</duration>
 
@@ -609,14 +609,14 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
                                 logging.debug(f'start_index= {tr.attrib["start_index"]}')
 
                                 if  tr.attrib['start_index'] == "0":
-                                    cell_def_tab.param_d[cell_def_name]["apoptosis_trate01"] = tr.text
-                                    cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_duration"] = invertf2s(tr.text)
+                                    cell_def_tab.param_d[cell_def_name]["apoptosis_01_trate"] = tr.text
+                                    cell_def_tab.param_d[cell_def_name]["apoptosis_01_duration"] = invertf2s(tr.text)
                                     if  tr.attrib['fixed_duration'].lower() == "true":
-                                        cell_def_tab.param_d[cell_def_name]["apoptosis_trate01_fixed"] = True
-                                        cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_fixed"] = True
+                                        cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_trate"] = True
+                                        cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_duration"] = True
                                     else:
-                                        cell_def_tab.param_d[cell_def_name]["apoptosis_trate01_fixed"] = False
-                                        cell_def_tab.param_d[cell_def_name]["apoptosis_phase0_fixed"] = False
+                                        cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_trate"] = False
+                                        cell_def_tab.param_d[cell_def_name]["apoptosis_01_fixed_duration"] = False
 
                     # apoptosis_params_path = apoptosis_path + "parameters//"
                     params_uep = death_model.find("parameters")
@@ -651,24 +651,24 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
                             logging.debug(f'{pd}')
                             logging.debug(f'index= {pd.attrib["index"]}')
                             if  pd.attrib['index'] == "0":
-                                cell_def_tab.param_d[cell_def_name]["necrosis_phase0_duration"] = pd.text
-                                cell_def_tab.param_d[cell_def_name]["necrosis_trate01"] = invertf2s(pd.text)
+                                cell_def_tab.param_d[cell_def_name]["necrosis_01_duration"] = pd.text
+                                cell_def_tab.param_d[cell_def_name]["necrosis_01_trate"] = invertf2s(pd.text)
                                 if  pd.attrib['fixed_duration'].lower() == "true":
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_phase0_fixed"] = True
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_trate01_fixed"] = True
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_duration"] = True
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_trate"] = True
                                 else:
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_phase0_fixed"] = False
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_trate01_fixed"] = False
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_duration"] = False
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_trate"] = False
 
                             elif  pd.attrib['index'] == "1":
-                                cell_def_tab.param_d[cell_def_name]["necrosis_phase1_duration"] = pd.text
-                                cell_def_tab.param_d[cell_def_name]["necrosis_trate12"] = invertf2s(pd.text)
+                                cell_def_tab.param_d[cell_def_name]["necrosis_12_duration"] = pd.text
+                                cell_def_tab.param_d[cell_def_name]["necrosis_12_trate"] = invertf2s(pd.text)
                                 if  pd.attrib['fixed_duration'].lower() == "true":
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_phase1_fixed"] = True
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_trate12_fixed"] = True
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_duration"] = True
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_trate"] = True
                                 else:
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_phase1_fixed"] = False
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_trate12_fixed"] = False
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_duration"] = False
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_trate"] = False
 
                     #------------------------
                     else:  # necrosis transition rates
@@ -690,33 +690,33 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
                                     # else:
                                         # dval = rate * 60.0
                                     logging.debug(f' --- transition rate 01 (float) = {rate}')
-                                    # cell_def_tab.param_d[cell_def_name]["necrosis_phase0_duration"] = tr.text
-                                    # cell_def_tab.param_d[cell_def_name]["necrosis_phase0_duration"] = str(dval)
-                                    # cell_def_tab.param_d[cell_def_name]["necrosis_trate01"] = str(dval)
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_trate01"] = str(rate)
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_phase0_duration"] = invertf2s(str(rate))
+                                    # cell_def_tab.param_d[cell_def_name]["necrosis_01_duration"] = tr.text
+                                    # cell_def_tab.param_d[cell_def_name]["necrosis_01_duration"] = str(dval)
+                                    # cell_def_tab.param_d[cell_def_name]["necrosis_01_trate"] = str(dval)
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_01_trate"] = str(rate)
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_01_duration"] = invertf2s(str(rate))
                                     if  tr.attrib['fixed_duration'].lower() == "true":
-                                        # cell_def_tab.param_d[cell_def_name]["necrosis_phase0_fixed"] = True
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_trate01_fixed"] = True
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_phase0_duration_fixed"] = True
+                                        # cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_duration"] = True
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_trate"] = True
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_duration"] = True
                                     else:
-                                        # cell_def_tab.param_d[cell_def_name]["necrosis_phase0_fixed"] = False
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_trate01_fixed"] = False
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_phase0_duration_fixed"] = False
+                                        # cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_duration"] = False
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_trate"] = False
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_01_fixed_duration"] = False
 
                                 elif  tr.attrib['start_index'] == "1":
                                     rate = float(tr.text)
                                     if abs(rate) < 1.e-6:
                                         rate = 1.e-6
                                     logging.debug(f' --- transition rate 12 (float) = {rate}')
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_trate12"] = str(rate)
-                                    cell_def_tab.param_d[cell_def_name]["necrosis_phase1_duration"] = invertf2s(str(rate))
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_12_trate"] = str(rate)
+                                    cell_def_tab.param_d[cell_def_name]["necrosis_12_duration"] = invertf2s(str(rate))
                                     if  tr.attrib['fixed_duration'].lower() == "true":
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_trate12_fixed"] = True
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_phase1_duration_fixed"] = True
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_trate"] = True
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_duration"] = True
                                     else:
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_trate12_fixed"] = False
-                                        cell_def_tab.param_d[cell_def_name]["necrosis_phase1_duration_fixed"] = False
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_trate"] = False
+                                        cell_def_tab.param_d[cell_def_name]["necrosis_12_fixed_duration"] = False
 
 
                     params_uep = death_model.find("parameters")
@@ -882,16 +882,18 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
             val =  uep.find(mechanics_options_path+"set_absolute_equilibrium_distance").text
             cell_def_tab.param_d[cell_def_name]["mechanics_absolute_equilibrium_distance"] = val
 
-            if uep.find(mechanics_options_path+"set_relative_equilibrium_distance").attrib['enabled'].lower() == 'true':
-                cell_def_tab.param_d[cell_def_name]["mechanics_relative_equilibrium_distance_enabled"] = True
-            else:
-                cell_def_tab.param_d[cell_def_name]["mechanics_relative_equilibrium_distance_enabled"] = False
+            rel_eq_bval = uep.find(mechanics_options_path+"set_relative_equilibrium_distance").attrib['enabled'].lower() == 'true'
+            cell_def_tab.param_d[cell_def_name]["mechanics_relative_equilibrium_distance_enabled"] = rel_eq_bval
 
-            if uep.find(mechanics_options_path+"set_absolute_equilibrium_distance").attrib['enabled'].lower() == 'true':
-                cell_def_tab.param_d[cell_def_name]["mechanics_absolute_equilibrium_distance_enabled"] = True
-            else:
-                cell_def_tab.param_d[cell_def_name]["mechanics_absolute_equilibrium_distance_enabled"] = False
+            abs_eq_bval = uep.find(mechanics_options_path+"set_absolute_equilibrium_distance").attrib['enabled'].lower() == 'true'
+            cell_def_tab.param_d[cell_def_name]["mechanics_absolute_equilibrium_distance_enabled"] = abs_eq_bval
 
+            if cell_def_name==cell_def_0th:
+                print(f"populate_tree_cell_defs.py: cell_def_name= {cell_def_name},  rel_eq_bval= {rel_eq_bval}, abs_eq_bval= {abs_eq_bval}")
+                cell_def_tab.set_relative_equilibrium_distance_enabled.setChecked(rel_eq_bval)
+                cell_def_tab.set_relative_equilibrium_distance_enabled.stateChanged.emit(rel_eq_bval)
+                cell_def_tab.set_absolute_equilibrium_distance_enabled.setChecked(abs_eq_bval)
+                cell_def_tab.set_absolute_equilibrium_distance_enabled.stateChanged.emit(abs_eq_bval)
 
             # <<< new (June 2022) mechanics params
             mypath =  uep.find(mechanics_path+"attachment_elastic_constant")
@@ -902,15 +904,15 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
 
             mypath =  uep.find(mechanics_path+"attachment_rate")
             if mypath is not None:
-                cell_def_tab.param_d[cell_def_name]["mechanics_attachment_rate"] = mypath.text
+                cell_def_tab.param_d[cell_def_name]["attachment_rate"] = mypath.text
             else:
-                cell_def_tab.param_d[cell_def_name]["mechanics_attachment_rate"] = '0.0'
+                cell_def_tab.param_d[cell_def_name]["attachment_rate"] = '0.0'
 
             mypath =  uep.find(mechanics_path+"detachment_rate")
             if mypath is not None:
-                cell_def_tab.param_d[cell_def_name]["mechanics_detachment_rate"] = mypath.text
+                cell_def_tab.param_d[cell_def_name]["detachment_rate"] = mypath.text
             else:
-                cell_def_tab.param_d[cell_def_name]["mechanics_detachment_rate"] = '0.0'
+                cell_def_tab.param_d[cell_def_name]["detachment_rate"] = '0.0'
 
             mypath =  uep.find(mechanics_path+"maximum_number_of_attachments")
             if mypath is not None:

--- a/bin/rules_tab.py
+++ b/bin/rules_tab.py
@@ -929,24 +929,24 @@ class Rules(QWidget):
             # print(behavior, cycle_model_idx )
             #{0:"live", 1:"basic Ki67", 2:"advanced Ki67", 3:"flow cytometry", 4:"Flow cytometry model (separated)", 5:"cycling quiescent"}
             if (behavior == 'cycle entry' or behavior == 'exit from cycle phase 0'):
-                if cycle_model_idx == 0 : base_val = self.celldef_tab.param_d[key0]['cycle_live_trate00']
-                elif cycle_model_idx == 1 : base_val = self.celldef_tab.param_d[key0]['cycle_Ki67_trate01']
-                elif cycle_model_idx == 2 : base_val = self.celldef_tab.param_d[key0]['cycle_advancedKi67_trate01']
-                elif cycle_model_idx == 3 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcyto_trate01']
-                elif cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_trate01']
-                elif cycle_model_idx == 5 : base_val = self.celldef_tab.param_d[key0]['cycle_quiescent_trate01']
+                if cycle_model_idx == 0 : base_val = self.celldef_tab.param_d[key0]['cycle_live_00_trate']
+                elif cycle_model_idx == 1 : base_val = self.celldef_tab.param_d[key0]['cycle_Ki67_01_trate']
+                elif cycle_model_idx == 2 : base_val = self.celldef_tab.param_d[key0]['cycle_advancedKi67_01_trate']
+                elif cycle_model_idx == 3 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcyto_01_trate']
+                elif cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_01_trate']
+                elif cycle_model_idx == 5 : base_val = self.celldef_tab.param_d[key0]['cycle_quiescent_01_trate']
             elif (behavior == 'exit from cycle phase 1'):
-                if cycle_model_idx == 1 : base_val = self.celldef_tab.param_d[key0]['cycle_Ki67_trate10']
-                elif cycle_model_idx == 2 : base_val = self.celldef_tab.param_d[key0]['cycle_advancedKi67_trate12']
-                elif cycle_model_idx == 3 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcyto_trate12']
-                elif cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_trate12']
-                elif cycle_model_idx == 5 : base_val = self.celldef_tab.param_d[key0]['cycle_quiescent_trate10']
+                if cycle_model_idx == 1 : base_val = self.celldef_tab.param_d[key0]['cycle_Ki67_10_trate']
+                elif cycle_model_idx == 2 : base_val = self.celldef_tab.param_d[key0]['cycle_advancedKi67_12_trate']
+                elif cycle_model_idx == 3 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcyto_12_trate']
+                elif cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_12_trate']
+                elif cycle_model_idx == 5 : base_val = self.celldef_tab.param_d[key0]['cycle_quiescent_10_trate']
             elif (behavior == 'exit from cycle phase 2'):
-                if cycle_model_idx == 2 : base_val = self.celldef_tab.param_d[key0]['cycle_advancedKi67_trate20']
-                elif cycle_model_idx == 3 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcyto_trate20']
-                elif cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_trate23']
+                if cycle_model_idx == 2 : base_val = self.celldef_tab.param_d[key0]['cycle_advancedKi67_20_trate']
+                elif cycle_model_idx == 3 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcyto_20_trate']
+                elif cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_23_trate']
             elif (behavior == 'exit from cycle phase 3'):
-                if cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_trate30']
+                if cycle_model_idx == 4 : base_val = self.celldef_tab.param_d[key0]['cycle_flowcytosep_30_trate']
                         
         elif btokens[0] in self.substrates:
             key1 = 'secretion'
@@ -991,9 +991,9 @@ class Rules(QWidget):
         elif behavior == "relative maximum adhesion distance":
             base_val = self.celldef_tab.param_d[key0]['mechanics_relative_equilibrium_distance']
         elif behavior == "cell attachment rate":
-            base_val = self.celldef_tab.param_d[key0]['mechanics_attachment_rate']
+            base_val = self.celldef_tab.param_d[key0]['attachment_rate']
         elif behavior == "cell detachment rate":
-            base_val = self.celldef_tab.param_d[key0]['mechanics_detachment_rate']
+            base_val = self.celldef_tab.param_d[key0]['detachment_rate']
         elif behavior == "maximum number of cell attachments":
             base_val = self.celldef_tab.param_d[key0]['mechanics_max_num_attachments']
 

--- a/bin/studio.py
+++ b/bin/studio.py
@@ -212,7 +212,7 @@ class PhysiCellXMLCreator(QWidget):
         self.num_models = 0
         self.model = {}  # key: name, value:[read-only, tree]
 
-        self.config_tab = Config(self.studio_flag)
+        self.config_tab = Config(self)
         self.config_tab_index = 0
         self.config_tab.xml_root = self.xml_root
         self.config_tab.fill_gui()
@@ -272,7 +272,7 @@ class PhysiCellXMLCreator(QWidget):
 
         self.microenv_tab.celldef_tab = self.celldef_tab
 
-        self.user_params_tab = UserParams()
+        self.user_params_tab = UserParams(self)
         self.user_params_tab.xml_root = self.xml_root
         self.user_params_tab.fill_gui()
 

--- a/bin/studio_classes.py
+++ b/bin/studio_classes.py
@@ -3,8 +3,9 @@ import sys
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QEvent
 from PyQt5.QtWidgets import QFrame, QCheckBox, QWidget, QLineEdit, QWidget, QComboBox, QLabel, QCompleter, QToolTip, QRadioButton
+from PyQt5.QtSvg import QSvgWidget
 from PyQt5.QtGui import QValidator, QDoubleValidator
-from PyQt5.QtCore import Qt, QSortFilterProxyModel, QEvent
+from PyQt5.QtCore import Qt, QSortFilterProxyModel, QEvent, QByteArray
 
 # organizers
 class QHLine(QFrame):
@@ -177,6 +178,13 @@ class HoverWidget(QWidget):
         super().__init__(parent)
         self.setMouseTracking(True)  # Enable mouse tracking
         self.hover_text = hover_text
+        self.setStyleSheet("QToolTip { \
+                            background-color: black; \
+                            color: white; \
+                            border: 1px solid black; \
+                            border-radius: 5px; \
+                            padding: 5px; \
+                            }")
     
     def setHoverText(self, hover_text):
         self.hover_text = hover_text
@@ -219,6 +227,22 @@ class HoverLabel(QLabel, HoverWidget):
             }
         """)
       
+class HoverSvgWidget(QSvgWidget, HoverWidget):
+    def __init__(self, hover_text, parent=None):
+        super().__init__(parent)
+        self.setHoverText(hover_text)
+
+class HoverWarning(HoverSvgWidget):
+    def __init__(self, hover_text, parent=None, width=15, height=15):
+        super().__init__(hover_text, parent)
+        self.setFixedSize(width, height)
+
+    def show_warning(self):
+        self.load("images:warning.svg")
+
+    def no_warning(self):
+        self.load(QByteArray()) # passing in an empty file path (self.load("")) works, but prints endless warnings about not being able to load the file
+        
 # validators
 
 class DoubleValidatorWidgetBounded(QValidator):
@@ -242,7 +266,7 @@ class DoubleValidatorWidgetBounded(QValidator):
             # then just record the info so the validator can access later
             self.top = top
             self.top_fn = top_transform
-        else:
+        elif top != None:
             # then just a normal top bound: transform if desired and set. then reset top and top_fn to None so they are not used later
             if top_transform is not None:
                 top = top_transform(top)

--- a/bin/user_params_tab.py
+++ b/bin/user_params_tab.py
@@ -68,9 +68,10 @@ class MyQLineEdit(QLineEdit):
 
 
 class UserParams(QWidget):
-    def __init__(self):
+    def __init__(self, xml_creator):
         super().__init__()
 
+        self.xml_creator = xml_creator
         # self.current_param = None
         self.xml_root = None
         self.count = 100
@@ -180,6 +181,7 @@ class UserParams(QWidget):
             w_varname.wrow = irow
             w_varname.wcol = self.var_icol_name
             w_varname.textChanged[str].connect(self.name_changed_cb)  # being explicit about passing a string 
+            w_varname.editingFinished.connect(self.name_change_finished_cb) 
 
             # ------- type
             w_var_type = MyQComboBox()
@@ -364,7 +366,8 @@ class UserParams(QWidget):
         self.add_row_utable(self.count - 1)
 
         # self.enable_all_custom_data()
-
+        if varname == "random_seed":
+            self.xml_creator.config_tab.random_seed_warning_label.no_warning()
     #----------------------------------------
     # Not currently used
     def disable_table_cells_for_duplicate_name(self, widget=None):
@@ -568,6 +571,10 @@ class UserParams(QWidget):
             for ival in range(N):
                 self.add_row_utable(self.count + ival)
             self.count += N
+
+    def name_change_finished_cb(self):
+        if self.sender().text()=="random_seed":
+            self.xml_creator.config_tab.random_seed_warning_label.show_warning()
 
     #----------------------------------------
     def units_changed_cb(self, text):


### PR DESCRIPTION
# Cell Def Tab changes
- standardize the creation of cycle layouts with standardized naming conventions
    - fix bug in writing to two cycle models 0->1 transition rates
- change naming conventions:
    - cycles are now cycle\_{name}\_{phase\_start\_idx}{phase\_end\_idx}\_{type}
        - name is the name of the cycle, e.g. Ki67
        - phase\_start\_idx and phase\_end\_idx are ints that represent the start and end indices of the phase in the cycle
        - type is either trate (transition rate) or duration
    - death transition rates are now {name}\_{phase\_start\_idx}{phase\_end\_idx}\_{type}
        - name is the name of the death model, apoptosis or necrosis
        - type is either trate (transition rate) or duration
    - the fixed indicators are now cycle\_{name}\_{phase\_start\_idx}{phase\_end\_idx}\_fixed\_{type} and {name}\_{phase\_start\_idx}{phase\_end\_idx}\_fixed\_{type}
        - fixed is in the middle so the checkboxes can just have the objectName "cycle\_{name}\_{phase\_start\_idx}{phase\_end\_idx}\_fixed" and then by appending the two types, they can easily be synced
        - similarly for the death models
- any param lineedit whose callback just sets a dict value just calls cell\_def\_param\_changed
    - use the objectName to get the key in the dict
- cell\_def\_param\_changed checks (optionally) if the name is already in the dict and raises an error if not
- check that durations/rates are not faster than the practical max
    - for phenotype rates, the callback is cell\_def\_pheno\_rate\_changed
    - for phenotype durations, the callback is cell\_def\_pheno\_duration\_changed
    - for mechanics rates, the callback is cell\_def\_mechano\_rate\_changed
    - for mechanics durations, the callback is cell\_def\_mechano\_duration\_changed
- if the rate/duration is too fast, a warning symbol pops up that gives info for the user on hovering
- safe handling of adhesion mechanics
    - only let one of the adhesion options be selected: default, relative, or absolute
    - make this visually clear for users
    - do not the relative > 2 or absolute > 2*radius of the cell as PhysiCell will just decrease them to 2 anyways
- removed need for `insert_hacky_blank_lines` in cell\_def\_tab.py

# Config Tab changes
- start shifting towards passing in xml\_creator into all tabs for easy access to all other tabs/flags
- convert warning about random\_seed in user\_parameters into a HoverWarning
- check if random\_seed is in user\_parameters whenever random\_seed here is toggled

# Populate Tree Cell Defs changes
- also update naming conventions as in cell\_def\_tab.py

# Rules Tab changes
- also update naming conventions as in cell\_def\_tab.py

# Studio changes
- start shifting towards passing in xml\_creator into all tabs for easy access to all other tabs/flags

# User Params Tab changes
- start shifting towards passing in xml\_creator into all tabs for easy access to all other tabs/flags
- update warning on config tab based on random\_seed being added/removed from user\_parameters