### PR TITLE
disable initial par dists in studio default config

### DIFF
--- a/config/PhysiCell_settings.xml
+++ b/config/PhysiCell_settings.xml
@@ -209,7 +209,7 @@
             <custom_data>
                 <sample conserved="false" units="dimensionless" description="">1.0</sample>
             </custom_data>
-            <initial_parameter_distributions enabled="true">
+            <initial_parameter_distributions enabled="false">
                 <distribution enabled="true" type="Uniform" check_base="false">
                     <behavior>substrate secretion target</behavior>
                     <min>0.01</min>


### PR DESCRIPTION
only use these if opted in to