### PR TITLE
restructure of ini par dists

### DIFF
--- a/bin/rules_tab.py
+++ b/bin/rules_tab.py
@@ -1994,7 +1994,7 @@ class Rules(QWidget):
         self.response_combobox.addItems(self.response_l)
 
         self.response_combobox.setCurrentIndex(0)
-        self.celldef_tab.fill_responses_widget(self.response_l + ["Volume"]) # everything else is lowercase, but this can stand out because it's not a true behavior, but rather the unique non-behavior that can be set by ICs
+        self.celldef_tab.par_dist_fill_responses_widget(self.response_l + ["Volume"]) # everything else is lowercase, but this can stand out because it's not a true behavior, but rather the unique non-behavior that can be set by ICs
 
     def create_response_list(self):
         # TODO: figure out how best to organize these responses

--- a/bin/sbml_intra.py
+++ b/bin/sbml_intra.py
@@ -597,7 +597,7 @@ The entry in column 2), 'phenotype', needs more explanation:\n\n"
         self.response_combobox.addItems(self.response_l)
 
         self.response_combobox.setCurrentIndex(0)
-        self.celldef_tab.fill_responses_widget(self.response_l + ["Volume"]) # everything else is lowercase, but this can stand out because it's not a true behavior, but rather the unique non-behavior that can be set by ICs
+        self.celldef_tab.par_dist_fill_responses_widget(self.response_l + ["Volume"]) # everything else is lowercase, but this can stand out because it's not a true behavior, but rather the unique non-behavior that can be set by ICs
 
     def create_response_list(self):
         # TODO: figure out how best to organize these responses

--- a/bin/studio_classes.py
+++ b/bin/studio_classes.py
@@ -177,7 +177,8 @@ class ExtendedCombo( QComboBox ):
 
 # hover widgets
 class HoverWidget(QWidget):
-    def __init__(self, hover_text=None, parent=None):
+    hover_enabled = True
+    def __init__(self, hover_text=None, parent=None, hover_enabled=True):
         super().__init__(parent)
         self.setMouseTracking(True)  # Enable mouse tracking
         self.hover_text = hover_text
@@ -188,11 +189,14 @@ class HoverWidget(QWidget):
                             border-radius: 5px; \
                             padding: 5px; \
                             }")
-    
+        self.hover_enabled = hover_enabled
+
     def setHoverText(self, hover_text):
         self.hover_text = hover_text
 
     def event(self, event):
+        if not self.hover_enabled:
+            return super().event(event)
         if event.type() == QEvent.Enter:
             # Display tooltip when the mouse enters the checkbox
             QToolTip.showText(event.globalPos(), self.hover_text, self)
@@ -243,9 +247,11 @@ class HoverHelp(HoverSvgWidget):
 
     def show_icon(self):
         self.load(self.icon)
+        self.hover_enabled = True
 
     def hide_icon(self):
         self.load(QByteArray()) # passing in an empty file path (self.load("")) works, but prints endless warnings about not being able to load the file
+        self.hover_enabled = False
 class HoverWarning(HoverHelp):
     def __init__(self, hover_text, parent=None, width=15, height=15):
         super().__init__(hover_text, parent)


### PR DESCRIPTION
- warnings and questions shown to help
- smoother switching between cell types
- stores even invalid updates for parameters to avoid secretly "setting" parameters 
  - "setting" because it was the previous value, not a new one 
  - this was happening if, e.g. Min=7 but then the user deletes 7 and moves away. the dictionary was still holding 7, waiting for an Acceptable input
- better handling of filling the response widget, just updating new values and removing old ones rather than clearing and re-adding all
- no longer storing cell_def_tab.response_l since we can easily get away with using the list and deleting it when we're done