### PR TITLE
Added option to display spring attachments

### DIFF
--- a/bin/filters2D.py
+++ b/bin/filters2D.py
@@ -98,6 +98,15 @@ class FilterUI2DWindow(QWidget):
         glayout.addWidget(self.cells_csv_button, idx_row,0,1,2) # w, row, column, rowspan, colspan
         #--------------------------------
 
+        #----------
+        idx_row += 1
+        glayout.addWidget(QHLine(), idx_row,0,1,4) # w, row, column, rowspan, colspan
+        idx_row += 1
+        self.attachments_checkbox = QCheckBox_custom('attachments')
+        self.attachments_checkbox.setChecked(self.vis_tab.attachments_checked_flag)
+        self.attachments_checkbox.clicked.connect(self.attachments_toggle_cb)
+        glayout.addWidget(self.attachments_checkbox)
+
         idx_row += 1
         glayout.addWidget(QHLine(), idx_row,0,1,4) # w, row, column, rowspan, colspan
         idx_row += 1
@@ -282,6 +291,11 @@ class FilterUI2DWindow(QWidget):
         # self.vis_tab.write_cells_csv_cb()
         self.vis_tab.phenotype_cb()
         pass
+
+    def attachments_toggle_cb(self, bval):
+        self.vis_tab.attachments_checked_flag = bval
+        self.vis_tab.update_plots()
+    
 
     def contour_mesh_cb(self):
         bval = self.contour_mesh_checkbox.isChecked()

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -488,6 +488,8 @@ class VisBase():
         self.fix_cmap_flag = False
         self.cells_edge_checked_flag = True
 
+        self.attachments_checked_flag = False
+
         self.contour_mesh = True
         self.contour_lines = False
         self.num_contours = 50
@@ -960,7 +962,7 @@ class VisBase():
 
         #------------------
         self.vbox.addWidget(QHLine())
-
+        
         hbox = QHBoxLayout()
         label = QLabel("folder")
         label.setAlignment(QtCore.Qt.AlignRight)

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -334,6 +334,10 @@ class Vis(VisBase, QWidget):
         self.ax0.cla()
         if self.substrates_checked_flag:  # do first so cells are plotted on top
             self.plot_substrate(self.current_frame)
+        
+        if self.attachments_checked_flag:
+            self.build_attachments(self.current_frame)
+        
         if self.cells_checked_flag:
             if self.plot_cells_svg:
                 self.plot_svg(self.current_frame)
@@ -387,6 +391,19 @@ class Vis(VisBase, QWidget):
 
         self.reset_model()
 
+    def build_attachments(self, frame):
+        fname = "output%08d_spring_attached_cells_graph.txt" % frame
+        path = os.path.join(self.output_dir, fname)
+        self.attachments = set()
+
+        if Path(path).is_file():
+            with open(path, 'r') as attachments_file:
+                for line in attachments_file.readlines()[1:]:
+                    cell, atts = line.split(":")
+                    if len(atts.strip()) > 0:
+                        for att in atts.split(","):
+                            self.attachments.add(tuple(sorted([int(cell), int(att.strip())])))
+            
     #------------------------------------------------------------
     # not currently used, but maybe useful
     def plot_vecs(self):
@@ -796,6 +813,10 @@ class Vis(VisBase, QWidget):
         else:
             cell_plot = self.circles(xvals,yvals, s=cell_radii, c=cell_scalar, cmap=cbar_name, vmin=vmin, vmax=vmax)
 
+        if self.attachments_checked_flag:
+            for c1,c2 in self.attachments:
+                self.ax0.plot([xvals[c1], xvals[c2]], [yvals[c1], yvals[c2]], 'k-', lw=0.5)
+    
         if self.cax2:
             try:
                 self.cax2.remove()
@@ -988,7 +1009,10 @@ class Vis(VisBase, QWidget):
         # print("# axes = ",num_axes)
         # if num_axes > 1: 
         # if self.axis_id_cellscalar:
-                
+        if self.attachments_checked_flag:
+            for c1,c2 in self.attachments:
+                self.ax0.plot([xvals[c1], xvals[c2]], [yvals[c1], yvals[c2]], 'k-', lw=0.5)
+    
         if( self.discrete_variable ): # Generic way: if variable is discrete
             # Then we don't need the cax2
             if self.cax2 is not None:


### PR DESCRIPTION
A long time ago already, I had played with this, and never submitted a PR. I remembered about it today, and thought it shouldn't disappear, so here it is !

![image](https://github.com/user-attachments/assets/8564120b-134a-41f1-acbf-f759a85b3e8c)

Just a simple option, accessible from the 2d plot options, to display the spring attachments between cells. For now, it only works in scalar or PhysiBoSS mode, not SVG. 

