### PR TITLE
on Import substrate ICs, automatically turn on

### DIFF
--- a/bin/ics_tab.py
+++ b/bin/ics_tab.py
@@ -598,12 +598,18 @@ class ICs(QWidget):
 
 
         hbox = QHBoxLayout()
+        ic_substrates_enabled_label = QLabel("Enable substrate ICs:")
+        hbox.addWidget(ic_substrates_enabled_label)
+        self.ic_substrates_enabled = QCheckBox_custom("")
+        hbox.addWidget(self.ic_substrates_enabled)
+        hbox.addStretch(1)
+
         label = QLabel("Substrate")
         label.setAlignment(QtCore.Qt.AlignRight)
         hbox.addWidget(label)
         
         self.substrate_combobox = QComboBox()
-        self.substrate_combobox.setFixedWidth(200)  # how wide is sufficient?
+        self.substrate_combobox.setFixedWidth(150)  # how wide is sufficient?
         self.substrate_combobox.currentIndexChanged.connect(self.substrate_combobox_changed_cb)
         hbox.addWidget(self.substrate_combobox)
 
@@ -618,7 +624,6 @@ class ICs(QWidget):
         self.ic_substrate_question_label.show_icon()
         hbox.addWidget(self.ic_substrate_question_label)
 
-        hbox.addStretch(1)
         self.vbox.addLayout(hbox)
 
         hbox = QHBoxLayout()
@@ -1237,6 +1242,8 @@ class ICs(QWidget):
         if self.mouse_pressed is False:
             self.update_substrate_plot(check_time_delay=False)
             return
+        if self.substrate_save_folder.text() != "" and self.substrate_save_file.text() != "":
+            self.ic_substrates_enabled.setChecked(True)
         x, y, z = self.getPos(event)
         if (x is None) or (y is None) or (z is None):
             self.current_voxel_subs = None
@@ -2180,7 +2187,7 @@ class ICs(QWidget):
         if ~nonzero_substrates.any():
             # then no substrates are being saved; just disable ics and move on
             print("---- All substrate ics are 0. Not saving and disabling ics")
-            self.enable_csv_for_substrate_ics = False
+            self.ic_substrates_enabled.setChecked(False)
             return
         
         print("----- Writing .csv file for substrate")
@@ -2190,7 +2197,7 @@ class ICs(QWidget):
         substrates_to_save = [self.substrate_list[i] for i in range(len(self.substrate_list)) if nonzero_substrates[i]]
         header = f'x,y,z,{",".join(substrates_to_save)}'
         np.savetxt(self.full_substrate_ic_fname, np.concatenate((X,Y,Z,C), axis=1), delimiter=',',header=header,comments='')
-        self.enable_csv_for_substrate_ics = True
+        self.ic_substrates_enabled.setChecked(True)
 
     #--------------------------------------------------
     def import_cb(self):
@@ -2304,9 +2311,24 @@ class ICs(QWidget):
         self.csv_folder.setText(self.config_tab.csv_folder.text())
         self.output_file.setText(self.config_tab.csv_file.text())
         self.fill_substrate_combobox()
+        self.fill_ic_substrates_widgets()
         if self.biwt_flag:
             self.biwt_tab.fill_gui()
-        
+
+    def fill_ic_substrates_widgets(self):
+        substrate_initial_condition_element = self.config_tab.xml_root.find(".//microenvironment_setup//options//initial_condition")
+        if substrate_initial_condition_element is None or substrate_initial_condition_element.attrib["enabled"].lower() == "false":
+            self.ic_substrates_enabled.setChecked(False)
+            return
+        path_to_file = substrate_initial_condition_element.find(".//filename").text
+        if os.path.isfile(path_to_file):
+            self.ic_substrates_enabled.setChecked(True)
+            self.substrate_save_folder.setText(os.path.dirname(path_to_file))
+            self.substrate_save_file.setText(os.path.basename(path_to_file))
+            self.full_substrate_ic_fname = path_to_file
+            self.import_substrate_from_file()
+        else:
+            self.ic_substrates_enabled.setChecked(False)
 
     def on_enter_axes(self, event):
         self.mouse_on_axes = True
@@ -2501,20 +2523,20 @@ class ICs(QWidget):
         self.plot_zz = np.arange(0,self.nz)*self.zdel+self.plot_zmin+0.5*self.zdel
         self.current_substrate_values = np.zeros((self.ny, self.nx)) # set it up for plotting
         self.all_substrate_values = np.zeros((self.ny, self.nx, len(self.substrate_list)))
-        self.enable_csv_for_substrate_ics = False # since we're reseting this here, might as well disable this
 
     def import_substrate_cb(self):
         filePath = QFileDialog.getOpenFileName(self,'',".")
-        full_path_file_name = filePath[0]
+        self.full_substrate_ic_fname = filePath[0]
 
-        self.import_substrate_from_file(full_path_file_name)
+        self.import_substrate_from_file()
 
-    def import_substrate_from_file(self, full_path_file_name):
-        if (len(full_path_file_name) == 0) or (not Path(full_path_file_name).is_file()):
-            print("import_substrate_from_file():  full_path_file_name is NOT valid")
+    def import_substrate_from_file(self):
+        if (len(self.full_substrate_ic_fname) == 0) or (not Path(self.full_substrate_ic_fname).is_file()):
+            print("import_substrate_from_file():  self.full_substrate_ic_fname is NOT valid")
+            self.ic_substrates_enabled.setChecked(False)
             return
 
-        with open(full_path_file_name, newline='') as csvfile:
+        with open(self.full_substrate_ic_fname, newline='') as csvfile:
             data = list(csv.reader(csvfile))
             if data[0][0]=='x': # check for header row
                 substrate_names = data[0][3:]
@@ -2527,12 +2549,15 @@ class ICs(QWidget):
                 # we could help the user out and load up what is there to work with, but they're probably better served by just getting a reality check with a reset to zeros
                 print(f"WARNING: Substrate IC CSV did not have the correct number of voxels ({data.shape[0]}!={self.nx*self.ny}). Reseting all concentrations to 0.")
                 self.setupSubstratePlotParameters()
+                self.ic_substrates_enabled.setChecked(False)
             else:
                 self.all_substrate_values[:,:,col_inds] = data[:,3:].reshape((self.ny, self.nx, -1))
                 self.current_substrate_values = self.all_substrate_values[:,:,self.substrate_combobox.currentIndex()]
+                self.ic_substrates_enabled.setChecked(True)
             check_time_delay = False
             self.update_substrate_plot(check_time_delay)
-
+        return
+        
     def checkForNewGrid(self):
         if float(self.config_tab.xmin.text())!=self.plot_xmin or float(self.config_tab.xmax.text())!=self.plot_xmax or float(self.config_tab.xdel.text())!=self.xdel \
             or float(self.config_tab.ymin.text())!=self.plot_ymin or float(self.config_tab.ymax.text())!=self.plot_ymax or float(self.config_tab.ydel.text())!=self.ydel:

--- a/bin/microenv_tab.py
+++ b/bin/microenv_tab.py
@@ -972,7 +972,7 @@ class SubstrateDef(QWidget):
         else:
             self.xml_root.find(".//options//track_internalized_substrates_in_each_agent").text = 'false'
     
-        if self.ics_tab.enable_csv_for_substrate_ics is True:
+        if self.ics_tab.ic_substrates_enabled.isChecked():
             if self.xml_root.find(".//microenvironment_setup//options//initial_condition") is None:
                 # add this eleement if it does not exist
                 elm = ET.Element("initial_condition", {"type":"csv", "enabled":'True'})


### PR DESCRIPTION
- previously, Import of substrate ICs did not activate their use.
- now much more robust way to enable, including on Save, Import, and begin drawing (so long as the file name is specified already)
- users can now control with a checkbox to override any automatic enabling of substrate ICs