### PR TITLE
on Import substrate ICs, automatically turn on

### DIFF
--- a/bin/microenv_tab.py
+++ b/bin/microenv_tab.py
@@ -972,7 +972,7 @@ class SubstrateDef(QWidget):
         else:
             self.xml_root.find(".//options//track_internalized_substrates_in_each_agent").text = 'false'
     
-        if self.ics_tab.enable_csv_for_substrate_ics is True:
+        if self.ics_tab.ic_substrates_enabled.isChecked():
             if self.xml_root.find(".//microenvironment_setup//options//initial_condition") is None:
                 # add this eleement if it does not exist
                 elm = ET.Element("initial_condition", {"type":"csv", "enabled":'True'})


### PR DESCRIPTION
- previously, Import of substrate ICs did not activate their use.
- now much more robust way to enable, including on Save, Import, and begin drawing (so long as the file name is specified and exists already)
- users can now control with a checkbox to override any automatic enabling of substrate ICs