### PR TITLE
support svg and jpg to print in Plots for 2D sims

### DIFF
--- a/bin/filters2D.py
+++ b/bin/filters2D.py
@@ -191,10 +191,16 @@ Note: only for .mat cell plots (not .svg)
         glayout.addWidget(self.mech_grid_size , idx_row,2, 1,1) # w, row, column, rowspan, colspan
 
         #--------------------------
-        self.save_png_checkbox = QCheckBox_custom('save frame*.png')
-        self.save_png_checkbox.clicked.connect(self.save_png_cb)
+        self.save_frame_checkbox = QCheckBox_custom('save frame*')
+        self.save_frame_checkbox.clicked.connect(self.save_frame_cb)
         idx_row += 1
-        glayout.addWidget(self.save_png_checkbox, idx_row,0,1,2) # w, row, column, rowspan, colspan
+        glayout.addWidget(self.save_frame_checkbox, idx_row,0,1,1) # w, row, column, rowspan, colspan
+
+        self.save_frame_filetype = QComboBox()
+        self.save_frame_filetype.addItems(['.png', '.svg', '.jpg'])
+        self.save_frame_filetype.currentIndexChanged.connect(self.save_frame_filetype_cb)
+        self.save_frame_filetype.setCurrentIndex(0)  # default to png
+        glayout.addWidget(self.save_frame_filetype, idx_row,1,1,1) # w, row, column, rowspan, colspan
 
         #--------------------
         # axes_act = view3D_menu.addAction("Axes")
@@ -335,9 +341,12 @@ Note: only for .mat cell plots (not .svg)
         except:
             pass
 
-    def save_png_cb(self):
-        self.vis_tab.png_frame = 0
-        self.vis_tab.save_png = self.save_png_checkbox.isChecked()
+    def save_frame_cb(self):
+        self.vis_tab.frame_ind = 0
+        self.vis_tab.save_frame = self.save_frame_checkbox.isChecked()
+
+    def save_frame_filetype_cb(self):
+        self.vis_tab.save_frame_filetype = self.save_frame_filetype.currentText()
         
     #--------
     def yz_slice_cb(self):

--- a/bin/filters3D.py
+++ b/bin/filters3D.py
@@ -189,10 +189,16 @@ class FilterUI3DWindow(QWidget):
         glayout.addWidget(QHLine(), idx_row,0,1,3) # w, row, column, rowspan, colspan
 
         idx_row += 1
-        self.save_png_checkbox = QCheckBox_custom('save frame*.png')
-        self.save_png_checkbox.clicked.connect(self.save_png_cb)
+        self.save_frame_checkbox = QCheckBox_custom('save frame*')
+        self.save_frame_checkbox.clicked.connect(self.save_frame_cb)
         idx_row += 1
-        glayout.addWidget(self.save_png_checkbox, idx_row,0,1,2) # w, row, column, rowspan, colspan
+        glayout.addWidget(self.save_frame_checkbox, idx_row,0,1,1) # w, row, column, rowspan, colspan
+
+        self.save_frame_filetype = QComboBox()
+        self.save_frame_filetype.addItems(['.png'])
+        self.save_frame_filetype.currentIndexChanged.connect(self.save_frame_filetype_cb)
+        self.save_frame_filetype.setCurrentIndex(0)  # default to png
+        glayout.addWidget(self.save_frame_filetype, idx_row,1,1,1) # w, row, column, rowspan, colspan
 
         idx_row += 1
         self.cells_csv_button = QPushButton("Save snap.csv")
@@ -369,9 +375,12 @@ class FilterUI3DWindow(QWidget):
         # print("vis_base: sphere_res_cb(): = ",int(text))
         self.vis_tab.sphere_res_cb(int(text))
 
-    def save_png_cb(self):
-        self.vis_tab.png_frame = 0
-        self.vis_tab.save_png = self.save_png_checkbox.isChecked()
+    def save_frame_cb(self):
+        self.vis_tab.frame_ind = 0
+        self.vis_tab.save_frame = self.save_frame_checkbox.isChecked()
+
+    def save_frame_filetype_cb(self):
+        self.vis_tab.save_frame_filetype = self.save_frame_filetype.currentText()
 
     def cells_csv_cb(self):
         self.vis_tab.write_cells_csv_cb()

--- a/bin/vis3D_tab.py
+++ b/bin/vis3D_tab.py
@@ -547,10 +547,13 @@ class Vis(VisBase, QWidget):
         # self.canvas.update()
         # self.canvas.draw()
 
-        if self.save_png:
-            self.png_frame += 1
-            png_file = os.path.join(self.output_dir, f"frame{self.png_frame:04d}.png")
-            print("---->  ", png_file)
+        if self.save_frame:
+            if self.save_frame_filetype != '.png':
+                print(f"\n\n----WARNING----\n\t3D printing not supported for {self.save_frame_filetype} filetype. Using .png instead.\n")
+                self.save_frame_filetype = '.png'
+            self.frame_ind += 1
+            frame_file = os.path.join(self.output_dir, f"frame{self.frame_ind:04d}{self.save_frame_filetype}")
+            print("---->  ", frame_file)
             windowto_image_filter = vtkWindowToImageFilter()
             windowto_image_filter.SetInput(self.vtkWidget.GetRenderWindow())
             windowto_image_filter.SetScale(1)  # image quality
@@ -563,7 +566,7 @@ class Vis(VisBase, QWidget):
                 windowto_image_filter.ReadFrontBufferOff()
                 windowto_image_filter.Update()
 
-            self.png_writer.SetFileName(png_file)
+            self.png_writer.SetFileName(frame_file)
             self.png_writer.SetInputConnection(windowto_image_filter.GetOutputPort())
             self.png_writer.Write()
 

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -324,8 +324,9 @@ class VisBase():
         self.rules_tab = rules_tab
         self.ics_tab = ics_tab
 
-        self.png_frame = 0
-        self.save_png= False
+        self.frame_ind = 0
+        self.save_frame_filetype = '.png'
+        self.save_frame= False
 
         # self.vis2D = True
         self.model3D_flag = model3D_flag 

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -84,7 +84,6 @@ class Vis(VisBase, QWidget):
         super(Vis,self).__init__(studio_flag=studio_flag, rules_flag=rules_flag,  nanohub_flag=nanohub_flag, config_tab=config_tab, microenv_tab=microenv_tab, celldef_tab=celldef_tab, user_params_tab=user_params_tab, rules_tab=rules_tab, ics_tab=ics_tab, run_tab=run_tab, model3D_flag=model3D_flag,tensor_flag=tensor_flag, ecm_flag=ecm_flag)
 
         self.figure = None
-        # self.png_frame = 0
 
         # self.vis2D = True
         # self.model3D_flag = model3D_flag
@@ -350,11 +349,11 @@ class Vis(VisBase, QWidget):
         self.canvas.update()
         self.canvas.draw()
 
-        if self.save_png:
-            self.png_frame += 1
-            png_file = os.path.join(self.output_dir, f"frame{self.png_frame:04d}.png")
-            print("---->  ", png_file)
-            self.figure.savefig(png_file)
+        if self.save_frame:
+            self.frame_ind += 1
+            frame_file = os.path.join(self.output_dir, f"frame{self.frame_ind:04d}{self.save_frame_filetype}")
+            print("---->  ", frame_file)
+            self.figure.savefig(frame_file)
 
 
     #------------------------------

--- a/bin/vis_tab_ecm.py
+++ b/bin/vis_tab_ecm.py
@@ -277,11 +277,11 @@ class Vis(VisBase, QWidget):
         self.canvas.update()
         self.canvas.draw()
 
-        if self.save_png:
-            self.png_frame += 1
-            png_file = os.path.join(self.output_dir, f"frame{self.png_frame:04d}.png")
-            print("---->  ", png_file)
-            self.figure.savefig(png_file)
+        if self.save_frame:
+            self.frame_ind += 1
+            frame_file = os.path.join(self.output_dir, f"frame{self.frame_ind:04d}{self.save_frame_filetype}")
+            print("---->  ", frame_file)
+            self.figure.savefig(frame_file)
 
     #------------------------------
     # Depends on 2D/3D


### PR DESCRIPTION
added a combobox in the view options window to allow users to select which filetype to save output to (.png, .jpg, or .svg). only support .png in 3D models for vtk. Default is .png.

Reason for this: I wanted to export an svg of what I saw in the Plots tab for easier post-processing

Some considerations:
- the index only resets if the checkbox is toggled; not if filetype is switched
- the printed svg has a bunch of clipping masks that feel unnecessary and make them larger than they probably need to be? I think this is just what matplotlib would do anytime an svg is printed, but if this needs produce smaller svg data files, this could be a place to target

